### PR TITLE
[EOSF-437] Use ember markdown-it to render abstract

### DIFF
--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -52,7 +52,7 @@
                     {{/if}}
                 </p>
                 <em class="m-r-md"> {{t "global.abstract"}}: </em>
-                <p class="abstract">{{if abstract abstract (t "global.none")}} </p>
+                <p class="abstract">{{if abstract (markdown-render abstract) (t "global.none")}} </p>
             {{else if (eq name 'Discipline')}}
                 {{#if subjects}}
                     {{#each subjects as |subject|}}

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -79,7 +79,7 @@
                     </div>
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                        <p class="abstract">{{node.description}}</p>
+                        <p class="abstract">{{markdown-render node.description}}</p>
                     </div>
 
                     {{#if model.doi}}

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "toastr": "^2.1.2",
     "hint.css": "^2.3.2",
     "jquery.tagsinput": "^1.3.6",
-    "loaders.css": "^0.1.2"
+    "loaders.css": "^0.1.2",
+    "markdown-it": "^8.2.2"
   },
   "resolutions": {
     "jquery": "~2.2.4"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ember-i18n": "4.3.1",
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "^0.5.1",
+    "ember-markdown-it": "0.0.5",
     "ember-metrics": "0.6.3",
     "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#ac254f87274044fb97d6a712efa5ff2433bd0537",
     "ember-page-title": "3.0.6",


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-437

## Purpose
Render markdown on abstract content, both in the edit/submit page and the content page.

## Changes
Use of `ember-markdown-it` package.




