### PR TITLE
[EOSF-436] Allow html to be used for provider descriptions

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -8,7 +8,7 @@
                 <div class="text-center m-t-lg col-xs-12">
                     <div class="preprint-brand"></div>
                     <p class="lead">
-                        <span>{{if theme.isProvider theme.provider.description (t "index.header.title.paragraph")}}</span>
+                        <span>{{if theme.isProvider (safe-markup theme.provider.description) (t "index.header.title.paragraph")}}</span>
                         {{#if theme.isProvider}}
                             <br>
                             <small>


### PR DESCRIPTION

## Ticket
https://openscience.atlassian.net/browse/EOSF-436

## Purpose
Allow PsyArxiv to have a link in their description.

## Changes
Allow html to be used for provider descriptions



