### PR TITLE
[blocked] Add blog link to branded footer [#EOSF-433]

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -250,6 +250,7 @@ export default {
             twitter: 'Twitter',
             facebook: 'Facebook',
             instagram: 'Instagram',
+            blog: 'Blog',
             support: `Support`,
             contact: `Contact`
         },

--- a/app/templates/components/preprint-footer-branded.hbs
+++ b/app/templates/components/preprint-footer-branded.hbs
@@ -43,6 +43,13 @@
                 <i class="fa fa-2x fa-instagram"></i>
             </a>
         {{/if}}
+        {{#if model.blogUrl}}
+            <a href="{{model.blogUrl}}"
+               aria-label={{t "components.preprint-footer-branded.blog"}}
+               onbeforeclick={{action 'click' 'link' 'Branded Footer - Blog'}}>
+                <i class="fa fa-2x fa-pencil"></i>
+            </a>
+        {{/if}}
     </div>
 
 


### PR DESCRIPTION
:warning: :squid: Requires merge of https://github.com/CenterForOpenScience/osf.io/pull/6821/files (OSF-7405) and https://github.com/CenterForOpenScience/ember-osf/pull/193

Then will need to update the ember-osf version in this repo to take advantage of the changes.

## Ticket
https://openscience.atlassian.net/browse/EOSF-433

## Purpose
Add a "blog" link to the preprint footer. 

![screen shot 2017-03-15 at 1 19 14 pm](https://cloud.githubusercontent.com/assets/2957073/23962370/47c83be8-0984-11e7-91de-2027293dbcbe.png)

## Changes
If preprint provider specifies a value for blog url, show a footer link.

## TODO
- [ ] If factories are added before this is merged, update the factories for a new field, and add unit tests for this component.

## Side effects
None expected



