### PR TITLE
[MOD-146][Fix] Hide status banner on private and abandoned preprints

### DIFF
--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -95,6 +95,15 @@ export default Ember.Controller.extend(Analytics, {
         return false;
     }),
 
+    showStatusBanner: Ember.computed('model.{provider.reviewsWorkflow,reviewsState}', 'userIsContrib', 'node.public', function() {
+        return (
+            this.get('model.provider.reviewsWorkflow')
+            && this.get('node.public')
+            && this.get('userIsContrib')
+            && this.get('model.reviewsState') !== 'initial'
+        );
+    }),
+
     twitterHref: Ember.computed('node', function() {
         const queryParams = {
             url: window.location.href,

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -46,7 +46,7 @@
             </div>
         </div> {{!END CONTAINER DIV}}
     </div> {{!END HEADER ROW}}
-    {{#if (and userIsContrib model.provider.reviewsWorkflow)}}
+    {{#if showStatusBanner}}
         {{preprint-status-banner submission=model}}
     {{/if}}
     <div id="view-page" class="container">{{!CONTAINER DIV}}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/MOD-146

## Purpose
`preprint-status-banner` breaks on preprints with state `initial` and is confusing/contradictory on preprints with private nodes.
<!-- Describe the purpose of your changes -->

## Changes
Hide `preprint-status-banner` on private and abandoned preprints
<!-- Briefly describe or list your changes  -->

## Side effects
None.
<!--Any possible side effects? -->



