### PR TITLE
[EOSF-859] Update node when license changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Get the sentryDSN from the ember config
 - Point Bower to new Bower registry (https://registry.bower.io)
 - Update to @centerforopenscience/ember-osf@0.11.0
+- Update node when license data is changed
 
 ### Removed
 - arXiv license permission language

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.114.0] - 2017-10-11
 ### Added
 - Dockerfile-alpine for small production builds

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -720,6 +720,12 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     },
                     license: this.get('basicsLicense.licenseType')
                 });
+                node.setProperties({
+                    description: currentAbstract,
+                    tags: currentTags,
+                    license: this.get('basicsLicense.licenseType'),
+                    nodeLicense: this.get('basicsLicense.licenseType'),
+                });
                 Ember.get(this, 'metrics')
                     .trackEvent({
                         category: 'dropdown',
@@ -734,7 +740,6 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     license: currentLicenseType,
                     doi: currentDOI,
                 });
-
                 node.setProperties({
                     description: currentAbstract,
                     tags: currentTags,


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-859

## Purpose

Currently, the node is not being updated whenever the license data on a preprint is being changed.  The changes should fix this.

## Changes

Add `node.setProperties()` section when updating after the license data is changed.