### PR TITLE
[EOSF-859] Update ember.js cdn version to 2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Hotfix
+- Update cdn to use ember.js version 2.8.3
+
 ## [0.114.1] - 2017-10-16
 ### Changed
 - Discover page locked parameters to "type: preprints" or "source: Thesis Commons"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -83,7 +83,7 @@ module.exports = function(defaults) {
                 enabled: useCdn,
                 content: `
                     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.7.1/ember.prod.js"></script>
+                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.8.3/ember.min.js"></script>
                 `.trim()
             },
         },


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-859

## Purpose

Update the ember.js cdn to point to the minified 2.8.3.