### PR TITLE
Use old-file-browser

### DIFF
--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -72,7 +72,7 @@
                                         </div>
                                     </form>
                                 </div>
-                                {{file-browser rootItem=osfStorageProvider openFile=(action 'selectFile')}}
+                                {{old-file-browser rootItem=osfStorageProvider openFile=(action 'selectFile')}}
                             {{/preprint-form-body}}
                         {{/preprint-form-section}}
                         {{#if (and selectedNode (or hasFile selectedFile)) use='crossFade'}}


### PR DESCRIPTION
## Purpose
We (read I) changed file-browser significantly to support quick files, which in turn broke usability for its one other use case, choosing a file from an existing node when creating a preprint.

