### PR TITLE
[Improvement][MOD-159] Add DOI message - Preprints

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -58,6 +58,8 @@ export default {
         version: 'Version',
         preprint_doi: `{{preprintWords.Preprint}} DOI`,
         article_doi: `Peer-reviewed Publication DOI`,
+        preprint_pending_doi: `DOI created after preprint is made public`,
+        preprint_pending_doi_moderation: `DOI created after moderator approval`,
         citations: `Citations`,
         disciplines: `Disciplines`,
         project_button: {

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -97,12 +97,18 @@
                         </div>
                     {{/if}}
 
-                    {{#if model.doi}}
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
+                    <div class="p-t-xs">
+                        {{#if model.doi}}
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
                             <a href={{doiUrl}} onlick={{action "click" "link" "Content - DOI" doiUrl}}>{{model.doi}}</a>
-                        </div>
-                    {{/if}}
+                        {{else if (not node.public)}}
+                            {{t 'content.preprint_pending_doi'}}
+                        {{else if (and model.provider.reviewsWorkflow (not model.isPublished))}}
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
+                            {{t 'content.preprint_pending_doi_moderation'}}
+                        {{/if}}
+                    </div>
+
 
                     {{#if model.license.name}}
                         <div class="p-t-xs">

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -104,7 +104,7 @@
                         {{else if (not node.public)}}
                             {{t 'content.preprint_pending_doi'}}
                         {{else if (and model.provider.reviewsWorkflow (not model.isPublished))}}
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
                             {{t 'content.preprint_pending_doi_moderation'}}
                         {{/if}}
                     </div>


### PR DESCRIPTION
## Problem
Users don't know when they will have a DOI for their preprint.

## Solution
Add "DOI created after moderator approval." on pending pre-moderation preprints

![image](https://user-images.githubusercontent.com/11130339/32010440-d5a48d12-b97f-11e7-8724-1b3c1c80475d.png)
![image](https://user-images.githubusercontent.com/11130339/32010455-da9d1776-b97f-11e7-90b1-3d437e3a2b02.png)

## Ticket
https://openscience.atlassian.net/browse/MOD-159