### PR TITLE
[EOSF-560] Fix search-facet-taxonomy-test

### DIFF
--- a/tests/integration/components/search-facet-taxonomy-test.js
+++ b/tests/integration/components/search-facet-taxonomy-test.js
@@ -1,4 +1,4 @@
-import { moduleForComponent, skip } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 
 const taxonomiesQuery = () => Ember.RSVP.resolve(Ember.ArrayProxy.create({
@@ -52,8 +52,8 @@ function render(context, componentArgs) {
     }}`));
 }
 
-skip('One-level hierarchy taxonomies', function(assert) {
+test('One-level hierarchy taxonomies', function(assert) {
     render(this);
-    assert.equal(this.$('label')[0].outerText.trim(), 'Arts and Humanities');
-    assert.equal(this.$('label')[1].outerText.trim(), 'Education');
+    assert.equal(this.$('label')[0].innerText.trim(), 'Arts and Humanities');
+    assert.equal(this.$('label')[1].innerText.trim(), 'Education');
 });


### PR DESCRIPTION
## Purpose

Broken ember test was skipped, needed updates

## Summary of Changes

Test was using a non-standard API that doesn't work in Firefox. Switched to innerText.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText

## Side Effects / Testing Notes

Nothing for QA, developer-facing changes only

## Ticket

https://openscience.atlassian.net/browse/EOSF-560

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
