### PR TITLE
[EOSF 886] make tests work in firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use COS ember-base image and multi-stage build
   - Notify DevOps prior to merging into master to update Jenkins
 
+### Fixed
+- component integration tests to work in Firefox
+  - provider-carousel
+  - search-facet-taxonomy
 
 ## [0.115.0] - 2017-10-27
 ### Added

--- a/tests/integration/components/provider-carousel-test.js
+++ b/tests/integration/components/provider-carousel-test.js
@@ -1,4 +1,4 @@
-import {moduleForComponent, skip} from 'ember-qunit';
+import {moduleForComponent, test} from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
@@ -6,7 +6,7 @@ moduleForComponent('provider-carousel', 'Integration | Component | provider caro
     integration: true
 });
 
-skip('it renders', function (assert) {
+test('it renders', function (assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
     this.set('provider1', Ember.Object.create({id: 'asu'}));
@@ -23,5 +23,5 @@ skip('it renders', function (assert) {
       providers=providers
     }}`);
 
-    assert.equal(this.$().context.innerText, 'PreviousNext');
+    assert.ok(/^\s*Previous\s*Next\s*$/.test(this.$().context.innerText));
 });

--- a/tests/integration/components/search-facet-taxonomy-test.js
+++ b/tests/integration/components/search-facet-taxonomy-test.js
@@ -1,4 +1,4 @@
-import { moduleForComponent, skip } from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 
 const taxonomiesQuery = () => Ember.RSVP.resolve(Ember.ArrayProxy.create({
@@ -52,8 +52,8 @@ function render(context, componentArgs) {
     }}`));
 }
 
-skip('One-level hierarchy taxonomies', function(assert) {
+test('One-level hierarchy taxonomies', function(assert) {
     render(this);
-    assert.equal(this.$('label')[0].outerText.trim(), 'Arts and Humanities');
-    assert.equal(this.$('label')[1].outerText.trim(), 'Education');
+    assert.equal(this.$('label')[0].innerText.trim(), 'Arts and Humanities');
+    assert.equal(this.$('label')[1].innerText.trim(), 'Education');
 });


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix the `provider-carousel` and `search-facet-taxonomy` component integration tests so they work with Firefox.

## Summary of Changes

* in `provider-carousel` test: use a RegEx to account for possible whitespace.
* in `search-facet-taxonomy` test: use innerText instead of non-standard outerText

## Side Effects / Testing Notes

Tests should now pass in Firefox.

## Ticket

https://openscience.atlassian.net/browse/EOSF-886

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
