### PR TITLE
[Hotfix] Change LiveData's filtered id

### DIFF
--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend(Analytics, {
     editedProviders: Ember.computed('providers', function() {
         let newProviders = Ember.A()
         for (const provider of this.get('providers')) {
-          if (provider && provider.get('id')!== 'asu') {
+          if (provider && provider.get('id')!== 'livedata') {
               newProviders.pushObject(provider)
           }
         }

--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend(Analytics, {
                 .findAll('preprint-provider')
                 .then(providers => {
                     const providerNames = providers.filter(
-                        provider => provider.get('id') !== 'asu'
+                        provider => provider.get('id') !== 'livedata'
                     ).map(provider => {
                         const name = provider.get('shareSource') || provider.get('name');
                         // TODO Change this in populate_preprint_providers script to just OSF


### PR DESCRIPTION
## Purpose

LiveData needs to be filtered out from the available preprint providers on the discover page.  This is done through removing if the id is equal to `asu` (its old ID).  LiveData has recently been updated with a new id of `livedata`.  The filter needs to be updated with the new id in order to keep filtering out LiveData. 

## Summary of Changes

Update the id being filtered from `asu` to `livedata`.

## Side Effects / Testing Notes

This should fix the issue of LiveData appearing on the discover page, but please make sure that it removes it completely (on the list, carousel, etc.)

## Ticket

None

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
