### PR TITLE
[EOSF-672] Add auto expansion on selected subjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - DOI message, used on the preprint detail page to show users when they will have a DOI for their preprint.
 - Headless Firefox
+- Auto-expansion on selected subjects on the Discover page
 
 ### Changed
 - Use yarn --frozen-lockfile instead of --pure-lockfile

--- a/app/components/search-facet-taxonomy.js
+++ b/app/components/search-facet-taxonomy.js
@@ -41,6 +41,7 @@ export default Ember.Component.extend(Analytics, {
                     showChildren: false,
                     childCount: result.get('child_count'),
                     shareTitle: result.get('shareTitle'),
+                    path: result.get('path'),
                 }))
                 .sort((prev, next) => {
                     if (prev.text > next.text) {
@@ -52,13 +53,40 @@ export default Ember.Component.extend(Analytics, {
                 })
             );
     },
+    // Creates a list of all of the subject paths that need to be selected
+    expandedList: Ember.computed('activeFilters.subjects', function() {
+        const filters = this.get('activeFilters.subjects');
+        let expandList = [];
+        filters.forEach(filter => {
+            let filterStr = '';
+            filter.split('|').forEach(item => {
+                if (item !== '') { filterStr += '|' + item; }
+                if (!expandList.includes(filterStr) && filterStr) {
+                    expandList.push(filterStr);
+                }
+            });
+        });
+        return expandList;
+    }),
     init() {
         this._super(...arguments);
+        const component = this;
+        let items = [];
 
         this._getTaxonomies()
-            .then(results => this
-                .set('topLevelItem', results)
-            );
+            .then(results => {
+                this.set('topLevelItem', results);
+                results.forEach(result => {
+                    component.get('expandedList').forEach(element => {
+                        if (element.includes(result.path + '|')) {
+                            if (!items.includes(result)) {
+                                items.push(result);
+                            }
+                        }
+                    })
+                });
+                this._expandMany(items);
+            });
     },
     actions: {
         expand(item) {
@@ -68,25 +96,45 @@ export default Ember.Component.extend(Analytics, {
                     action: item.showChildren ? 'contract' : 'expand',
                     label: `Discover - ${item.text}`
                 });
+            this._expand(item);
+        }
+    },
+    _expand(item) {
+        if (item.showChildren) {
+            Ember.set(item, 'showChildren', false);
+            return;
+        }
+        let children = item.children;
 
-            if (item.showChildren) {
-                Ember.set(item, 'showChildren', false);
-                return;
-            }
-
-            const children = item.children;
-
-            if (children && children.length > 0) {
+        if (children && children.length > 0) {
+            Ember.set(item, 'showChildren', true);
+            return;
+        }
+        return this._getTaxonomies(item.id)
+            .then((results) => {
+                Ember.set(item, 'children', results);
                 Ember.set(item, 'showChildren', true);
-                return;
-            }
+                return results;
+            });
+    },
+    // Runs through the expandedList.  If the subject's path is in the list,
+    // then add it to the list.  Recursively runs through the list and expands.
+    _expandMany(items) {
+        const component = this;
 
-            this._getTaxonomies(item.id)
-                .then(results => {
-                    Ember.set(item, 'children', results);
-                    Ember.set(item, 'showChildren', true);
-                }
-            );
+        if (items.length) {
+            this._expand(items.shift()).then(results => {
+                results.forEach(result => {
+                    component.get('expandedList').forEach(element => {
+                        if (element.includes(result.path + '|')) {
+                            if (!items.includes(result)) {
+                                items.push(result);
+                            }
+                        }
+                    });
+                });
+                component._expandMany(items);
+            });
         }
     }
 });


### PR DESCRIPTION
## Purpose

If the user has some subjects selected when navigating to the `Discover` page, the subject list will only show the top-level subjects regardless of whether or not other level subjects have been selected.  This makes it look like you haven't selected any second or third level subjects.  This change will auto-expand all of the subjects you have selected.

## Summary of Changes

- Add functions that will break up the `activeFilters` and query for subjects based on each level

## Side Effects / Testing Notes

The changes added will loop through each level of the subjects list based on the `activeFilters` and expand them if they have a child selected.  They will *only* expand if at least one child is selected.  So no matter if the top-level subject is selected or not, if there is a child selected it should expand.  

Please be sure to test that all levels will expand as expected.  It should expand when there is a child selected.  It should not expand if there is not a child selected.

## Ticket

https://openscience.atlassian.net/browse/EOSF-672

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
