### PR TITLE
[EOSF-881] Fix contrast issue for error pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - component integration tests to work in Firefox
   - provider-carousel
   - search-facet-taxonomy
+- CSS contrast issue for support email link on some branded provider error pages.
 
 ## [0.115.1] - 2017-11-07
 ## Changed

--- a/app/components/error-page.js
+++ b/app/components/error-page.js
@@ -3,7 +3,7 @@ import Analytics from 'ember-osf/mixins/analytics';
 
 export default Ember.Component.extend(Analytics, {
     theme: Ember.inject.service(),
-    classNames: ['preprint-error-page'],
+    classNames: ['preprint-header', 'preprint-header-error'],
     label: '',
     translationKey: '',
     supportEmail: Ember.computed('theme.isProvider', 'theme.provider.emailSupport', function() {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -7,6 +7,7 @@
 @import 'validated-input';
 @import 'hint';
 @import 'daterangepicker.scss';
+@import 'error-page.scss';
 
 /* Override styles from ember-osf and osf */
 .footer {

--- a/app/styles/error-page.scss
+++ b/app/styles/error-page.scss
@@ -1,0 +1,7 @@
+div .preprint-header-error {
+    padding-top: 70px;
+
+    .container {
+        margin-bottom: 60px;
+    }
+}


### PR DESCRIPTION
## Purpose

Currently, the color contrast for support email link on ECSarxiv and EarthArxiv error pages are not enough. This PR fix the issue.

## Summary of Changes

Change the component's CSS class to 'prerpint-header' and 'preprint-hearder-error'.
Added a style file to the component to add padding and bottom margin.

## Side Effects / Testing Notes

The error page for OSF preprint would also be changed to using the background image on the landing page, which should be more consistent.

## Ticket

https://openscience.atlassian.net/browse/EOSF-881

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
