### PR TITLE
[Improvement][EOSF-914] Update edit button wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use yarn --frozen-lockfile instead of --pure-lockfile
 - Use COS ember-base image and multi-stage build
   - Notify DevOps prior to merging into master to update Jenkins
+- Wording on `Edit preprint` button to `Edit and resubmit` on preprint detail page if the preprint is rejected
+ and the workflow is pre-moderation.
+ 
 
 ### Fixed
 - component integration tests to work in Firefox

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -45,8 +45,10 @@ function queryStringify(queryParams) {
 const DATE_LABEL = {
     created: 'content.date_label.created_on',
     submitted: 'content.date_label.submitted_on'
-}
+};
 const PRE_MODERATION = 'pre-moderation';
+const REJECTED = 'rejected';
+const INITIAL = 'initial';
 
 /**
  * @module ember-preprints
@@ -78,6 +80,15 @@ export default Ember.Controller.extend(Analytics, {
             this.get('model.dateCreated');
     }),
 
+    editButtonLabel: Ember.computed('model.provider.reviewsWorkflow', 'model.reviewsState', function () {
+        const edit_preprint = 'content.project_button.edit_preprint';
+        const edit_resubmit_preprint = 'content.project_button.edit_resubmit_preprint';
+        return (
+            this.get('model.provider.reviewsWorkflow') === PRE_MODERATION
+            && this.get('model.reviewsState') == REJECTED
+        ) ? edit_resubmit_preprint : edit_preprint
+    }),
+
     isAdmin: Ember.computed('node', function() {
         // True if the current user has admin permissions for the node that contains the preprint
         return (this.get('node.currentUserPermissions') || []).includes(permissions.ADMIN);
@@ -100,7 +111,7 @@ export default Ember.Controller.extend(Analytics, {
             this.get('model.provider.reviewsWorkflow')
             && this.get('node.public')
             && this.get('userIsContrib')
-            && this.get('model.reviewsState') !== 'initial'
+            && this.get('model.reviewsState') !== INITIAL
         );
     }),
 

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -85,8 +85,8 @@ export default Ember.Controller.extend(Analytics, {
         const edit_resubmit_preprint = 'content.project_button.edit_resubmit_preprint';
         return (
             this.get('model.provider.reviewsWorkflow') === PRE_MODERATION
-            && this.get('model.reviewsState') == REJECTED
-        ) ? edit_resubmit_preprint : edit_preprint
+            && this.get('model.reviewsState') === REJECTED
+        ) ? edit_resubmit_preprint : edit_preprint;
     }),
 
     isAdmin: Ember.computed('node', function() {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -65,7 +65,8 @@ export default {
         project_button: {
             paragraph: `The project for this paper is available on the OSF.`,
             button: `Visit project`,
-            edit_preprint:  `Edit {{preprintWords.preprint}}`
+            edit_preprint:  `Edit {{preprintWords.preprint}}`,
+            edit_resubmit_preprint: `Edit and resubmit`
         },
         orphan_preprint: `The user has removed this file.`,
         private_preprint_warning: `This {{preprintWords.Preprint}} is private. Make it discoverable by making`,

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -37,7 +37,7 @@
                            href={{concat theme.guidPathPrefix model.id '/edit'}}
                            onclick={{action "click" 'link' "Content - Edit Preprint" (concat model.links.html 'edit')}}
                         >
-                            {{t "content.project_button.edit_preprint"}}
+                            {{t editButtonLabel}}
                         </a>
                     {{/if}}
                     <br>

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -21,6 +21,7 @@ moduleFor('controller:content/index', 'Unit | Controller | content/index', {
         'model:citation',
         'model:license',
         'model:wiki',
+        'model:taxonomy',
         'service:metrics',
         'service:theme'
     ]
@@ -266,6 +267,41 @@ test('fullLicenseText computed property', function (assert) {
             ctrl.get('fullLicenseText'),
             'The year is 2000.'
         );
+    });
+});
+
+test('editButtonLabel computed property', function (assert) {
+    this.inject.service('store');
+
+    const store = this.store;
+    const ctrl = this.subject();
+
+    Ember.run(() => {
+        const provider = store.createRecord('preprint-provider', {
+            reviewsWorkflow: 'pre-moderation',
+        });
+
+        const model = store.createRecord('preprint', {
+            provider,
+            reviewsState: 'initial',
+        });
+
+        ctrl.setProperties({model});
+
+        const workflowTypes = ['pre-moderation', 'post-moderation'];
+        const stateTypes = ['pending', 'accepted', 'rejected'];
+        for (let i = 0; i < workflowTypes.length; i++) {
+            for (let j = 0; j < stateTypes.length; j++) {
+                ctrl.set('model.provider.reviewsWorkflow', workflowTypes[i]);
+                ctrl.set('model.reviewsState', stateTypes[j]);
+                if (workflowTypes[i] == 'pre-moderation' && stateTypes[j] == 'rejected') {
+                    assert.strictEqual( ctrl.get('editButtonLabel'), 'content.project_button.edit_resubmit_preprint');
+                } else {
+                    assert.strictEqual( ctrl.get('editButtonLabel'), 'content.project_button.edit_preprint');
+                }
+
+            }
+        }
     });
 });
 


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Change wording on "Edit preprint" button to "Edit and resubmit" on preprint detail page if the preprint is rejected and the workflow is pre-moderation.

Why:
Some users might think to resubmit means go through the submission process again instead of editing their current preprint and resubmitting.

## Summary of Changes


- Use a computed property to determine the wording based on provider's review workflow and preprint status.
- Update translation file
- Update changelog

![image](https://user-images.githubusercontent.com/11130339/32797475-de0df07c-c93f-11e7-9458-4f3177ed44b4.png)

![image](https://user-images.githubusercontent.com/11130339/32797749-b4f3ceae-c940-11e7-9c17-b777c4c261ee.png)



## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/MOD-182

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [x] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
