### PR TITLE
[EOSF-950] Hotfix - remove hard-coded advisory board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## hotfix
+### Changed
+- Removed hard-coded advisory board
+
 ## [0.115.6] - 2017-12-04
 ### Changed
 - Update to ember-osf@0.12.4

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -106,37 +106,13 @@
 
 
     {{!ADVISORY GROUP}}
-    <div class="preprint-advisory p-v-md">
-        <div class="container">
-            <div class="row">
-                {{#if (and theme.isProvider theme.provider.advisoryBoard.length)}}
+    {{#if theme.provider.advisoryBoard.length}}
+        <div class="preprint-advisory p-v-md">
+            <div class="container">
+                <div class="row">
                     {{sanitize-html theme.provider.advisoryBoard "advisory-board"}}
-                {{else if (not theme.isProvider)}}
-                    <div class="col-xs-12">
-                        <h2>{{t "index.advisory.heading"}}</h2>
-                        <p class="m-b-lg">{{t "index.advisory.paragraph"}}</p>
-                    </div>
-                    <div class="col-xs-6">
-                        <ul>
-                            <li><b>Devin Berg :</b> engrXiv, University of Wisconsin-Stout</li>
-                            <li><b>Pete Binfield :</b> PeerJ PrePrints</li>
-                            <li><b>Benjamin Brown :</b> PsyArXiv, Georgia Gwinnett College</li>
-                            <li><b>Philip Cohen :</b> SocArXiv, University of Maryland</li>
-                            <li><b>Kathleen Fitzpatrick :</b> Modern Language Association</li>
-                            <li><b>John Inglis :</b> bioRxiv, Cold Spring Harbor Laboratory Press</li>
-                        </ul>
-                    </div>
-                    <div class="col-xs-6">
-                        <ul>
-                            <li><b>Rebecca Kennison :</b> K|N Consultants</li>
-                            <li><b>Bethany Nowviskie :</b> Digital Library Federation, University of Virginia</li>
-                            <li><b>Kristen Ratan :</b> CoKo Foundation</li>
-                            <li><b>Oya Rieger :</b> arXiv, Cornell University</li>
-                            <li><b>Judy Ruttenberg :</b> SHARE, Association of Research Libraries</li>
-                        </ul>
-                    </div>
-                {{/if}}
+                </div>
             </div>
         </div>
-    </div>
+    {{/if}}
 </div> {{!END INDEX}}


### PR DESCRIPTION
## Purpose

At the moment, unbranded preprints is using hard-coded data for the advisory board.  We should be using data from the admin app.

## Summary of Changes

Remove hard-coded section and altered the conditional that determines when to show it.

## Ticket

https://openscience.atlassian.net/browse/EOSF-950

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
