### PR TITLE
[EOSF-952] Add donate button to branded navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## hotfix
+### Added
+- Donate button to branded navbar
+
 ## [0.115.7] - 2017-12-05
 ### Changed
 - For unbranded preprints, use advisor board from API rather than hard-coded

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -379,6 +379,7 @@ export default {
             my_projects: `My OSF Projects`,
             headline: `On the OSF`,
             reviews: `My Reviewing`,
+            donate: `Donate`,
         },
         'preprint-status-banner': {
             message: {

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -27,6 +27,11 @@
                 </li>
             {{/if}}
             <li><a class="" href='{{theme.pathPrefix}}discover' onclick={{action "click" "link" "Navbar - Search"}}>{{t "global.search"}}</a></li>
+            <li>
+                <a href="https://cos.io/donate" onclick={{action "click" "link" (concat "Navbar - Donate")}}>
+                    {{t "components.preprint-navbar-branded.donate"}}
+                </a>
+            </li>
             {{navbar-auth-dropdown
                 signupUrl=theme.signupUrl
                 loginAction=(action 'login')


### PR DESCRIPTION
## Purpose

To add the donate button to the branded navbar.

## Summary of Changes

Add donate button (without special styling)

![screen shot 2017-12-05 at 3 19 00 pm](https://user-images.githubusercontent.com/19379783/33629612-b0fba054-d9d2-11e7-82b7-0e42f9e0ee3c.png)


## Side Effects / Testing Notes

The donate button should show up on branded preprints, with the same styling as the other buttons.  It should not have any styling like it does on the OSF side (mainly just no green text).

## Ticket

https://openscience.atlassian.net/browse/EOSF-952

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
