### PR TITLE
[EOSF-889] Add JavaScript disabled message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - DOI message, used on the preprint detail page to show users when they will have a DOI for their preprint.
 - Headless Firefox
 - Auto-expansion on selected subjects on the Discover page
+- `noscript` message if JavaScript is disabled
 
 ### Changed
 - Use yarn --frozen-lockfile instead of --pure-lockfile

--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,13 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
   </head>
   <body>
+    <noscript>
+        <p>
+        For full functionality of this site it is necessary to enable JavaScript.
+        Here are the
+            <a href='https://www.enable-javascript.com/' target='_blank'> instructions how to enable JavaScript in your web browser</a>.
+        </p>
+    </noscript>
     {{content-for "body"}}
 
     {{content-for "cdn"}}


### PR DESCRIPTION
## Purpose

If the user does not have JavaScript enabled on their browser, preprints shows up as a blank white screen.  This will add an error message and a link that shows users how to enable JavaScript to use the site.

## Summary of Changes

- Add `<noscript>` message

![screen shot 2017-12-07 at 2 30 55 pm](https://user-images.githubusercontent.com/19379783/33734707-46eaae6e-db5b-11e7-92d0-b8b2e13dbf7f.png)

## Ticket

https://openscience.atlassian.net/browse/EOSF-889

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
