### PR TITLE
[EOSF-885] Review action rename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  and the workflow is pre-moderation.
 - Removed footer styling
 - Updated `meta.total` to `meta.total_pages` in preprint-form-authors component
+- Modified `preprint-status-banner` component for review action rename.
 
 ### Fixed
 - component integration tests to work in Firefox

--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -61,9 +61,9 @@ export default Ember.Component.extend({
         if (this.get('submission.provider.reviewsCommentsPrivate')) {
             this.set('latestAction', null);
         } else {
-            this.get('submission.actions').then(actions => {
-                if (actions.length) {
-                    this.set('latestAction', actions.get('firstObject'));
+            this.get('submission.reviewActions').then(reviewActions => {
+                if (reviewActions.length) {
+                    this.set('latestAction', reviewActions.get('firstObject'));
                 } else {
                     this.set('latestAction', null);
                 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-20T19:13:46Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-20T20:54:27Z",
     "@centerforopenscience/osf-style": "1.5.1",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -4,7 +4,7 @@ import config from 'ember-get-config';
 
 moduleFor('controller:content/index', 'Unit | Controller | content/index', {
     needs: [
-        'model:action',
+        'model:review-action',
         'model:file',
         'model:file-version',
         'model:comment',

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -42,7 +42,7 @@ moduleFor('controller:submit', 'Unit | Controller | submit', {
         'service:theme',
         'service:toast',
         'service:i18n',
-        'model:action',
+        'model:review-action',
         'model:file',
         'model:file-version',
         'model:comment',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-20T19:13:46Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-20T20:54:27Z":
   version "0.12.4"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#3bc4e9a76112d6480fc3e4ce76376080bae2d32b"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#8329921fc1b38bf8744d379185527d4d8b8dffa3"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

This is the second PR to the [previous one](https://github.com/CenterForOpenScience/ember-osf/pull/329) for `action` model renaming.

## Summary of Changes

in `components/preprint-status-banner`, because the newly renamed `review-action` model is associated to the `preprint` model with a new key `reviewActions` instead of `actions` (see [this line](https://github.com/CenterForOpenScience/ember-osf/pull/329/files#diff-17a82615d478139017c35d835342db7aL39) in the previous PR.), `submission.actions` is changed to `submission.reviewActions`.

## Side Effects / Testing Notes


## Ticket

https://openscience.atlassian.net/browse/EOSF-885

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
