### PR TITLE
[EOSF-951] Update to use latest ember-osf

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-04T21:20:08Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-12T15:51:48Z",
     "@centerforopenscience/osf-style": "1.5.1",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-04T21:20:08Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-12T15:51:48Z":
   version "0.12.4"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#ba7a1f233dfb522da3a979a67a612163ca4e8cc5"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#79077c5fa4ba183ee47afa10d7d1703ae3084f0c"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

Fixes have been done in `ember-osf` to get the dropzone area clickable on preprints again.  This PR updates to the latest `ember-osf` to use those changes.

## Summary of Changes

Update `yarn.lock` file and use the latest `ember-osf`

## Ticket

https://openscience.atlassian.net/browse/EOSF-951

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
