### PR TITLE
[EOSF-879] Update preprint to show alert when DOI is being minted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Wording on `Edit preprint` button to `Edit and resubmit` on preprint detail page if the preprint is rejected
  and the workflow is pre-moderation.
 - Removed footer styling
-- Change preprint content page to show prompt if DOI is not yet minted.
 
 ### Fixed
 - component integration tests to work in Firefox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Wording on `Edit preprint` button to `Edit and resubmit` on preprint detail page if the preprint is rejected
  and the workflow is pre-moderation.
 - Removed footer styling
+- Change preprint content page to show prompt if DOI is not yet minted.
 
 ### Fixed
 - component integration tests to work in Firefox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `noscript` message if JavaScript is disabled
 - Favicons are updated to reflect their provider, on a branded domain or on a /preprints/provider page
 - DOI message, used on the preprint detail page to show users when they will have a DOI for their preprint.
+- Show a message on detail page when a DOI is created but not yet minted that it takes up to 24 hours to be minted.
 
 ### Changed
 - Use yarn --frozen-lockfile instead of --pure-lockfile

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -58,8 +58,6 @@ export default {
         version: 'Version',
         preprint_doi: `{{preprintWords.Preprint}} DOI`,
         article_doi: `Peer-reviewed Publication DOI`,
-        preprint_pending_doi: `DOI created after preprint is made public`,
-        preprint_pending_doi_moderation: `DOI created after moderator approval`,
         preprint_pending_doi_minted: `DOIs are minted by a third party, and may take up to 24 hours to be registered.`,
         citations: `Citations`,
         disciplines: `Disciplines`,

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -58,6 +58,9 @@ export default {
         version: 'Version',
         preprint_doi: `{{preprintWords.Preprint}} DOI`,
         article_doi: `Peer-reviewed Publication DOI`,
+        preprint_pending_doi: `DOI created after preprint is made public`,
+        preprint_pending_doi_moderation: `DOI created after moderator approval`,
+        preprint_pending_doi_minted: `DOIs are minted by a third party, and may take up to 24 hours to be registered.`,
         citations: `Citations`,
         disciplines: `Disciplines`,
         project_button: {

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -91,10 +91,17 @@
                     </div>
 
                     {{#if model.links.preprint_doi}}
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
-                            <a href={{model.links.preprint_doi}} onclick={{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
-                        </div>
+                        {{#if model.preprintDoiCreated}}
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
+                                <a href={{model.links.preprint_doi}} onclick={{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
+                            </div>
+                        {{else}}
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
+                                {{t "content.preprint_pending_doi_minted"}}
+                            </div>
+                        {{/if}}
                     {{/if}}
 
                     {{#if model.doi}}

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -91,17 +91,15 @@
                     </div>
 
                     {{#if model.links.preprint_doi}}
-                        {{#if model.preprintDoiCreated}}
-                            <div class="p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
+                        <div class="p-t-xs">
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
+                            {{#if model.preprintDoiCreated}}
                                 <a href={{model.links.preprint_doi}} onclick={{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
-                            </div>
-                        {{else}}
-                            <div class="p-t-xs">
-                                <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
-                                {{t "content.preprint_pending_doi_minted"}}
-                            </div>
-                        {{/if}}
+                            {{else}}
+                                <p> {{extract-doi model.links.preprint_doi}} </p>
+                                <p> {{t "content.preprint_pending_doi_minted"}} </p>
+                            {{/if}}
+                        </div>
                     {{/if}}
 
                     {{#if model.doi}}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-12T15:51:48Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-14T21:46:52Z",
     "@centerforopenscience/osf-style": "1.5.1",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-12T15:51:48Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-12-14T21:46:52Z":
   version "0.12.4"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#79077c5fa4ba183ee47afa10d7d1703ae3084f0c"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#f8575f4afe2fc36a8e5390562e662376d06d68b4"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

This PR complements [the previous PR](https://github.com/CenterForOpenScience/ember-osf/pull/330) to show alert when DOI is being minted.

## Summary of Changes

In `translation.js`, a prompt message for doi being minted is added.
In `templates/content/index.hbs`, the template is changed to show the prompt message when DOI is being minted.

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-879

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
