### PR TITLE
[EOSF-839] Make use of fingerprinted osf-assets for OSF Preprint logoSharing

### DIFF
--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -96,7 +96,7 @@ export default Ember.Service.extend({
             type: 'image/png',
             width: 1200,
             height: 630
-        }
+        };
         return logo;
     }),
 

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -91,19 +91,11 @@ export default Ember.Service.extend({
     logoSharing: Ember.computed('id', 'isDomain', function() {
         const id = this.get('id');
         let logo = {};
-        if (id === 'osf') {
-            logo = config.PREPRINTS.providers
-                .find(provider => provider.id === id)
-                .logoSharing;
-
-            logo.path = pathJoin('/preprints', logo.path);
-        } else {
-            logo = {
-                path: buildProviderAssetPath(config, id, 'sharing.png', this.get('isDomain')),
-                type: 'image/png',
-                width: 1200,
-                height: 630
-            }
+        logo = {
+            path: buildProviderAssetPath(config, id, 'sharing.png', this.get('isDomain')),
+            type: 'image/png',
+            width: 1200,
+            height: 630
         }
         return logo;
     }),

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -90,14 +90,12 @@ export default Ember.Service.extend({
     // The logo object for social sharing
     logoSharing: Ember.computed('id', 'isDomain', function() {
         const id = this.get('id');
-        let logo = {};
-        logo = {
+        return {
             path: buildProviderAssetPath(config, id, 'sharing.png', this.get('isDomain')),
             type: 'image/png',
             width: 1200,
             height: 630
         };
-        return logo;
     }),
 
     // The url to redirect users to sign up to

--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
-import pathJoin from '../utils/path-join';
 import buildProviderAssetPath from '../utils/build-provider-asset-path';
 
 /**

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,19 +38,6 @@ module.exports = function(environment) {
         },
         PREPRINTS: {
             defaultProvider: 'osf',
-            // Logos are needed for open graph sharing meta tags (Facebook, LinkedIn, etc) and must be at least 200x200
-            providers: [
-                // OSF must be the first provider
-                {
-                    id: 'osf',
-                    logoSharing: {
-                        path: '/assets/img/provider_logos/osf-dark.png',
-                        type: 'image/png',
-                        width: 363,
-                        height: 242
-                    }
-                }
-            ],
         },
         i18n: {
             defaultLocale: 'en'

--- a/tests/unit/services/theme-test.js
+++ b/tests/unit/services/theme-test.js
@@ -13,8 +13,6 @@ test('it exists', function(assert) {
 });
 
 test('themes have proper config', function(assert) {
-    let providers = config.PREPRINTS.providers;
-    for (var provider of providers) {
-        assert.ok(typeof provider.id !== 'undefined');
-    }
+    let defaultProvider = config.PREPRINTS.defaultProvider;
+    assert.equal(defaultProvider, 'osf');
 });


### PR DESCRIPTION
## Purpose

Currently, the `og:image` meta tags for OSF Preprint reference to an incorrect asset. This change should fix that to refer to fingerprinted assets in our osf-assets repo. 

## Summary of Changes

In `theme.js`, OSF Preprint's `logo.path` is no longer referencing to assets in ember-osf-preprints. Instead, it is changed to use the same `buildProviderAssetPath` method that builds fingerprinted assets urls for all provider assets.
Therefore, `environment.js` is changed to remove the `providers` list that includes information that is no longer necessary for building OSF Preprint assets.

## Side Effects / Testing Notes

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-839

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
