### PR TITLE
[hotfix] Add settings for prerender

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -24,6 +24,8 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
   </head>
   <body>
+    <script> window.prerenderReady = false; </script>
+
     {{content-for "body"}}
 
     {{content-for "cdn"}}

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -59,5 +59,12 @@ export default Ember.Route.extend(Analytics, OSFAgnosticAuthRouteMixin, {
 
         if (locale)
             this.set('i18n.locale', locale);
-    }
+    },
+
+    actions: {
+        didTransition: function() {
+          window.prerenderReady = true;
+          return true; // Bubble the didTransition event
+        }
+    },
 });


### PR DESCRIPTION
## Purpose
The newest version prerender uses Chrome to render pages and is aggressive about not waiting for async requests. In order to guarantee that the entire page is loaded rendered, we need to set `window.prerenderReady = false` when the page first loads, and once the rendering is complete, set `window.prerenderRead = true`

Ref: 
* https://prerender.io/documentation/best-practices
* https://github.com/prerender/prerender/blob/c63413ac2359144f16641874dc0a748c075515f1/lib/browsers/chrome.js#L435-L455


## Summary of Changes
Adds script to index.html and application route didTransition action hook


## Side Effects / Testing Notes

@jamescdavis  @CenterForOpenScience/reviews we'll need to do this in the other ember repositories as well. Preprints has the slowest page load time, so this is the priority.

Once this is up on staging/production, add `?_escaped_fragment_=` to see the prerendered page.

**Note: this is blocking production prerender updates. The old version of prerender technically works, but caching with is not, so we're getting very slow page loads and this is hurting SEO**

## Ticket

N/A

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
