### PR TITLE
Bubble didTransition event in the content route

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -262,6 +262,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
             const ev = document.createEvent('HTMLEvents');
             ev.initEvent('ZoteroItemUpdated', true, true);
             document.dispatchEvent(ev);
+            return true; // Bubble the didTransition event
         }
     }
 });


### PR DESCRIPTION
## Purpose

didTransition is not bubbling, causing prerender to timeout (`window.prerenderReady` is always `false`)

## Summary of Changes



## Side Effects / Testing Notes



## Ticket

https://openscience.atlassian.net/browse/EOSF-

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
