### PR TITLE
[IN-23][Preprints] Fall back to use fullName when user have no givenName and familyName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update tests to work with model.queryHasMany
 - Get pagination info directly from meta in preprint-form-authors component
 - Check for `has_highlighted_subjects` flag to determine what wording should be used on index page
+- Use newly added `name` field for preprint detail page contributors
 
 ## [0.116.4] - 2018-01-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- Use newly added `name` field for preprint detail page contributors
-
 ### Added
 - Default auto-expansion on top level subjects when there are no more than 3.
 - Check to use `facebookAppId` if branded providers have an app id
@@ -16,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 'Powered by Preprints' link stay on current server
 - Searching for contributors also searches their social links (such as their twitter handle)
 - Pull more preprint data (`title`, `description`, `tags`, etc.) from the preprint model instead of the node model.
+- Use newly added `name` field for preprint detail page contributors
 
 ### Fixed
 - Skipped tests in `convert-or-copy-project-test` and `supplementary-file-browser` to run properly
@@ -27,7 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.117.4] - 2018-02-21
 ### Fixed
 - Increase taxonomies page size from 100 to 150
-
 
 ## [0.117.3] - 2018-02-20
 ### Changed

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -14,7 +14,7 @@
                                         {{#if author.unregisteredContributor}}
                                             <li>{{author.unregisteredContributor}}</li>
                                         {{else}}
-                                            <li><a href={{author.users.profileURL}} onclick={{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.givenName}} {{author.users.familyName}}</a></li>
+                                            <li><a href={{author.users.profileURL}} onclick={{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.name}}</a></li>
                                         {{/if}}
                                     {{/if}}
                                 {{~/each}}


### PR DESCRIPTION
## Purpose

This is the second of two PRs (the first one is [here](https://github.com/CenterForOpenScience/ember-osf/pull/346)) to make sure preprint detail page will fall back to using fullName of contributors.

## Summary of Changes

In `index.hbs`, use newly added `name` field of the `user` model.

## Side Effects / Testing Notes

There are four scenarios to test:
1. givenName, familyName and fullName are all defined: should show "{givenName} {familyName}"
2. only givenName and fullName are defined: should show "{fullName}"
3. only familyName and fullName are defined: should show "{fullName}"
4. only fullName is defined: should show "{fullName}"

Note: fullName is always defined because it is a required field for users.

## Ticket

https://openscience.atlassian.net/browse/IN-23

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
