### PR TITLE
[IN-73] Fix malformed url of og-image on staging

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -90,7 +90,15 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 const peerDoi = preprint.get('doi');
                 const doi = peerDoi ? peerDoi : mintDoi;
                 const image = this.get('theme.logoSharing');
-                const imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
+                let imageUrl;
+                let secure_url;
+                if (image.path.indexOf('http://') < 0 || image.path.indexOf('https://') < 0) {
+                    imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
+                    secure_url = `${origin}${image.path}`;
+                } else {
+                    imageUrl = image.path.replace(/^https/, 'http');
+                    secure_url = image.path;
+                }
                 const dateCreated = new Date(preprint.get('dateCreated') || null);
                 const dateModified = new Date(preprint.get('dateModified') || dateCreated);
                 if (!preprint.get('datePublished'))
@@ -105,7 +113,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['fb:app_id', config.FB_APP_ID],
                     ['og:title', title],
                     ['og:image', imageUrl],
-                    ['og:image:secure_url', `${origin}${image.path}`], // We should always be on https in staging/prod
+                    ['og:image:secure_url', secure_url], // We should always be on https in staging/prod
                     ['og:image:width', image.width.toString()],
                     ['og:image:height', image.height.toString()],
                     ['og:image:type', image.type],

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -90,15 +90,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 const peerDoi = preprint.get('doi');
                 const doi = peerDoi ? peerDoi : mintDoi;
                 const image = this.get('theme.logoSharing');
-                let imageUrl;
-                let secure_url;
-                if (image.path.indexOf('http://') < 0 || image.path.indexOf('https://') < 0) {
-                    imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
-                    secure_url = `${origin}${image.path}`;
-                } else {
-                    imageUrl = image.path.replace(/^https/, 'http');
-                    secure_url = image.path;
-                }
+                const imageUrl = /^https?:\/\//.test(image.path) ? image.path : origin + image.path;
                 const dateCreated = new Date(preprint.get('dateCreated') || null);
                 const dateModified = new Date(preprint.get('dateModified') || dateCreated);
                 if (!preprint.get('datePublished'))
@@ -113,7 +105,6 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['fb:app_id', config.FB_APP_ID],
                     ['og:title', title],
                     ['og:image', imageUrl],
-                    ['og:image:secure_url', secure_url], // We should always be on https in staging/prod
                     ['og:image:width', image.width.toString()],
                     ['og:image:height', image.height.toString()],
                     ['og:image:type', image.type],


### PR DESCRIPTION
## Purpose

During testing, @laurenrevere found out that the og:image url on staging is malformed. This fixes the issue.

## Summary of Changes

A conditional is added to prepend `origin` to `imageUrl` and `secure_url` only if `image.path` is not already a full url.

## Side Effects / Testing Notes

Check that staging no longer has malformed og:image url. After that you should be able to test Twitter and Facebook sharing.

## Ticket

https://openscience.atlassian.net/browse/IN-73

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
