### PR TITLE
[IN-72] improve preprint logo visibility on osf preprints landing page

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1457,6 +1457,7 @@ nav.branded-navbar {
     margin-right: auto;
 
     .provider-logo-item {
+        display: block;
         flex: 1 0 auto;
         box-sizing: border-box;
         height: 120px;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1453,12 +1453,11 @@ nav.branded-navbar {
     display: flex;
     flex-wrap: wrap;
     padding: 20px;
-    max-width: 1000px;
     margin-left: auto;
     margin-right: auto;
 
     .provider-logo-item {
-        flex: 1 0 25%;
+        flex: 1 0 auto;
         box-sizing: border-box;
         height: 120px;
         background-size: contain;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -82,7 +82,7 @@
                 <div class="row p-v-md">
                     <div class="provider-logos">
                         {{#each model.brandedProviders as |provider| }}
-                            <div class="provider-logo-item" style="background-image: url({{provider-asset provider.id 'wide_white.png'}});"></div>
+                            <a href="{{brandedPreprintUrl provider}}" title="{{provider.name}}" class="provider-logo-item" style="background-image: url({{provider-asset provider.id 'wide_white.png'}});"></a>
                         {{/each}}
                     </div>
                 </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -79,33 +79,33 @@
                         <p class="m-b-lg">{{t "index.services.top.paragraph"}}</p>
                     </div>
                 </div>
-            </div>
-            <div class="row p-v-md">
-                <div class="provider-logos">
-                    {{#each model.brandedProviders as |provider| }}
-                        <div class="provider-logo-item" style="background-image: url({{provider-asset provider.id 'wide_white.png'}});"></div>
-                    {{/each}}
+                <div class="row p-v-md">
+                    <div class="provider-logos">
+                        {{#each model.brandedProviders as |provider| }}
+                            <div class="provider-logo-item" style="background-image: url({{provider-asset provider.id 'wide_white.png'}});"></div>
+                        {{/each}}
+                    </div>
                 </div>
-            </div>
-            <div class="row p-v-md">
-                <div class="col-md-12 text-center">
-                    <p class="lead">
-                        {{t "index.services.bottom.p1"}}
-                        <div class="p-t-sm">
-                            {{t "index.services.bottom.div.line1"}}
-                            <a class="source_code_link" href="https://github.com/CenterForOpenScience/ember-preprints"
-                                onclick={{action "click" "link" "Index - GitHub Repo" "https://github.com/CenterForOpenScience/ember-preprints"}}>
-                                {{t "index.services.bottom.div.linkText1"}}
-                            </a>
-                            {{t "index.services.bottom.div.line2"}}
-                            <a class="source_code_link" href="https://docs.google.com/spreadsheets/d/1SocElbBjc_Nhme4-SJv2_zytBd1ys8R5aZDb3POe94c/edit#gid=1340026270"
-                                onclick={{action "click" "link" "Index - Requirements and Roadmap" "https://docs.google.com/spreadsheets/d/1SocElbBjc_Nhme4-SJv2_zytBd1ys8R5aZDb3POe94c/edit#gid=1340026270"}}>
-                                {{t "index.services.bottom.div.linkText2"}}
-                            </a>
-                            {{t "index.services.bottom.div.line3"}}
-                        </div>
-                    </p>
-                    <a href="mailto:contact@osf.io" class="btn btn-info btn-lg" onclick={{action 'contactLink' emailHref 'link' 'click' 'Index - contact email'}}>{{t "index.services.bottom.contact"}}</a>
+                <div class="row p-v-md">
+                    <div class="col-md-12 text-center">
+                        <p class="lead">
+                            {{t "index.services.bottom.p1"}}
+                            <div class="p-t-sm">
+                                {{t "index.services.bottom.div.line1"}}
+                                <a class="source_code_link" href="https://github.com/CenterForOpenScience/ember-preprints"
+                                    onclick={{action "click" "link" "Index - GitHub Repo" "https://github.com/CenterForOpenScience/ember-preprints"}}>
+                                    {{t "index.services.bottom.div.linkText1"}}
+                                </a>
+                                {{t "index.services.bottom.div.line2"}}
+                                <a class="source_code_link" href="https://docs.google.com/spreadsheets/d/1SocElbBjc_Nhme4-SJv2_zytBd1ys8R5aZDb3POe94c/edit#gid=1340026270"
+                                    onclick={{action "click" "link" "Index - Requirements and Roadmap" "https://docs.google.com/spreadsheets/d/1SocElbBjc_Nhme4-SJv2_zytBd1ys8R5aZDb3POe94c/edit#gid=1340026270"}}>
+                                    {{t "index.services.bottom.div.linkText2"}}
+                                </a>
+                                {{t "index.services.bottom.div.line3"}}
+                            </div>
+                        </p>
+                        <a href="mailto:contact@osf.io" class="btn btn-info btn-lg" onclick={{action 'contactLink' emailHref 'link' 'click' 'Index - contact email'}}>{{t "index.services.bottom.contact"}}</a>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

* allow Preprint provider logos display on preprints index page to use full container width
* make Preprint provider logos links again

## Summary of Changes

* remove `max-width` on logos container
* move logos and contact containers to within preprint services container
* change to `flex-basis: auto`
* change logo `div` tags to `a` tags that link to provider and `display:block`

## Side Effects / Testing Notes

Make sure this works correctly in all supported browsers. Flexbox is supposed to be [fully supported in all major browsers](https://caniuse.com/#feat=flexbox), but apparently has some bugs in IE 11 (see the Known Issues tab).

## Ticket

https://openscience.atlassian.net/browse/IN-72

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(already described in [previous PR](https://github.com/CenterForOpenScience/ember-osf-preprints/pull/518))*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
