### PR TITLE
[IN-45][Preprints] Truncate unicode strings correctly for Linkedin sharing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Default auto-expansion on top level subjects when there are no more than 3.
 - Check to use `facebookAppId` if branded providers have an app id
 - Choose preprint provider during unbranded submission
+- Add `unicode-byte-truncate` as a dependency
 
 ### Changed
 - 'Powered by Preprints' link stay on current server
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Skipped tests in `convert-or-copy-project-test` and `supplementary-file-browser` to run properly
+- Do unicode-aware truncating for LinkedIn sharing using `unicode-byte-truncate`
 
 ## [0.117.5] - 2018-02-22
 ### Changed

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -4,6 +4,7 @@ import loadAll from 'ember-osf/utils/load-relationship';
 import config from 'ember-get-config';
 import Analytics from 'ember-osf/mixins/analytics';
 import permissions from 'ember-osf/const/permissions';
+import trunc from 'npm:unicode-byte-truncate'
 
 /**
  * Takes an object with query parameter name as the key and value, or [value, maxLength] as the values.
@@ -141,8 +142,8 @@ export default Ember.Controller.extend(Analytics, {
         const queryParams = {
             url: [window.location.href, 1024],          // required
             mini: ['true', 4],                          // required
-            title: [this.get('node.title'), 200],      // optional
-            summary: [this.get('node.description'), 256], // optional
+            title: trunc(this.get('node.title'), 200),      // optional
+            summary: trunc(this.get('node.description'), 256), // optional
             source: ['Open Science Framework', 200]     // optional
         };
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "loader.js": "4.0.1",
     "pagination-pager": "2.4.2",
     "postcss": "5.1.0",
-    "unicode-byte-truncate": "^1.0.0",
+    "unicode-byte-truncate": "^1.0.0"
   },
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-preprints/issues"

--- a/package.json
+++ b/package.json
@@ -96,5 +96,8 @@
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-preprints/issues"
   },
-  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme"
+  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme",
+  "dependencies": {
+    "unicode-byte-truncate": "^1.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -91,13 +91,13 @@
     "liquid-fire": "0.27.3",
     "loader.js": "4.0.1",
     "pagination-pager": "2.4.2",
-    "postcss": "5.1.0"
+    "postcss": "5.1.0",
+    "unicode-byte-truncate": "^1.0.0",
   },
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-preprints/issues"
   },
   "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme",
   "dependencies": {
-    "unicode-byte-truncate": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -97,7 +97,5 @@
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-preprints/issues"
   },
-  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme",
-  "dependencies": {
-  }
+  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme"
 }

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { moduleFor, test, skip } from 'ember-qunit';
 import config from 'ember-get-config';
+import trunc from 'npm:unicode-byte-truncate'
 
 moduleFor('controller:content/index', 'Unit | Controller | content/index', {
     needs: [
@@ -117,6 +118,33 @@ test('linkedinHref computed property', function (assert) {
             `https://www.linkedin.com/shareArticle?url=${location}&mini=true&title=test%20title&summary=test%20description&source=Open%20Science%20Framework`
         );
     });
+});
+
+test('trunc() works properly: only unicode', function (assert) {
+    //Each Chinese characters is 3 bytes long in Unicode.
+    let unicodeString = '上下而求索';
+    let expectedTruncatedString = '上下';
+    assert.strictEqual(trunc(unicodeString, 6), expectedTruncatedString);
+    assert.strictEqual(trunc(unicodeString, 7), expectedTruncatedString);
+    assert.strictEqual(trunc(unicodeString, 8), expectedTruncatedString);
+});
+
+test('trunc() works properly: only ASCII', function (assert) {
+    let asciiString = 'ascii string';
+    assert.strictEqual(trunc(asciiString, 5), 'ascii');
+    assert.strictEqual(trunc(asciiString, 6), 'ascii ');
+    assert.strictEqual(trunc(asciiString, 7), 'ascii s');
+});
+
+test('trunc() works properly: ASCII and Unicode', function (assert) {
+    let unicodeString = 'Open Science 开放科学';
+    assert.strictEqual(trunc(unicodeString, 13), 'Open Science ');
+    assert.strictEqual(trunc(unicodeString, 14), 'Open Science ');
+    assert.strictEqual(trunc(unicodeString, 15), 'Open Science ');
+    assert.strictEqual(trunc(unicodeString, 16), 'Open Science 开');
+    assert.strictEqual(trunc(unicodeString, 17), 'Open Science 开');
+    assert.strictEqual(trunc(unicodeString, 18), 'Open Science 开');
+    assert.strictEqual(trunc(unicodeString, 19), 'Open Science 开放');
 });
 
 test('emailHref computed property', function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,7 +5122,7 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-integer@^1.0.4:
+is-integer@^1.0.4, is-integer@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-integer/-/is-integer-1.0.7.tgz#6bde81aacddf78b659b6629d629cadc51a886d5c"
   dependencies:
@@ -8464,6 +8464,17 @@ underscore.string@~3.3.4:
 underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+unicode-byte-truncate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-byte-truncate/-/unicode-byte-truncate-1.0.0.tgz#aa6f0f3475193fe20c320ac9213e36e62e8764a7"
+  dependencies:
+    is-integer "^1.0.6"
+    unicode-substring "^0.1.0"
+
+unicode-substring@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/unicode-substring/-/unicode-substring-0.1.0.tgz#6120ce3c390385dbcd0f60c32b9065c4181d4b36"
 
 unique-filename@~1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Purpose

When a user clicks on the Linkedin sharing button on some preprints with Unicode encoded strings as titles or descriptions, the pop-up sharing page says "page not found". This is because Linkedin sharing works quite differently in that it gets sharing information from the query parameters of the sharing URL, which we construct on the front end side. Because javascript is not Unicode-aware, when we truncate Unicode strings according to specified length limit, it breaks the encoding and therefore causing errors for Linkedin when parsing the URL. 
This PR fix the problem by using an NPM package to do Unicode-aware string truncating.

## Summary of Changes

An NPM package `unicode-byte-truncate` is added as a dependency.
In `controllers/content/index.js`, `trunc` from the newly added dependency is used to truncate the title and description.

## Side Effects / Testing Notes

None.

## Ticket

https://openscience.atlassian.net/browse/IN-45

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
