### PR TITLE
[IN-97][Preprints] Get more data from preprint model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Pull more preprint data (`title`, `description`, `tags`, etc.) from the preprint model instead of the node model.
 
 ## [0.117.3] - 2018-02-20
 ### Changed

--- a/app/components/convert-or-copy-project.js
+++ b/app/components/convert-or-copy-project.js
@@ -9,7 +9,7 @@ import Analytics from 'ember-osf/mixins/analytics';
  * Convert Or Copy Widget - very simple, just presents decision, do you want to convert this project or copy file to a new component.
  *
  * Will set convertOrCopy to 'convert' or 'copy'.  If convert, will set node title as current node title and titleValid to
- * true. If 'copy', nodeTitle will be set equal to null, and titleValid to false.  Converting a project requires the user confirm their
+ * true. If 'copy', title will be set equal to null, and titleValid to false.  Converting a project requires the user confirm their
  * decision in an additional step.
  *
  * Sample usage:
@@ -17,7 +17,7 @@ import Analytics from 'ember-osf/mixins/analytics';
  * {{convert-or-copy-project
  *  convertOrCopy=convertOrCopy
  *  titleValid=titleValid
- *  nodeTitle=nodeTitle
+ *  title=title
  *  node=node
  *  convertProjectConfirmed=convertProjectConfirmed
  *}}
@@ -32,7 +32,7 @@ export default Ember.Component.extend(Analytics, {
             this.set('convertProjectConfirmed', false);
             this.set('convertOrCopy', 'copy');
             this.set('titleValid', false);
-            this.set('nodeTitle', null);
+            this.set('title', null);
             this.attrs.nextUploadSection('organize', 'finalizeUpload');
             Ember.get(this, 'metrics')
                 .trackEvent({
@@ -47,7 +47,7 @@ export default Ember.Component.extend(Analytics, {
             this.set('convertProjectConfirmed', false);
             this.set('convertOrCopy', 'convert');
             if (this.get('node')) {
-                this.set('nodeTitle', this.get('node.title'));
+                this.set('title', this.get('node.title'));
                 this.set('titleValid', true);
             }
             Ember.get(this, 'metrics')

--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -32,7 +32,7 @@ import Analytics from 'ember-osf/mixins/analytics';
  *   startState=_State.START
  *   existingState=existingState
  *   _existingState=_existingState
- *   nodeTitle=nodeTitle
+ *   title=title
  *   currentUser=user
  *   osfFile=selectedFile
  *   hasFile=hasFile
@@ -140,7 +140,7 @@ export default Ember.Component.extend(Analytics, {
             this.get('store').createRecord('node', {
                 public: false,
                 category: 'project',
-                title: this.get('nodeTitle'),
+                title: this.get('title'),
             }).save()
                 .then(node => {
                     this.set('node', node);
@@ -165,7 +165,7 @@ export default Ember.Component.extend(Analytics, {
                 });
             let node = this.get('node');
             node
-                .addChild(this.get('nodeTitle'))
+                .addChild(this.get('title'))
                 .then(child => {
                     this.set('parentNode', node);
                     this.set('node', child);
@@ -195,8 +195,8 @@ export default Ember.Component.extend(Analytics, {
             let node = this.get('node');
             this.set('basicsAbstract', this.get('node.description') || null);
             let currentTitle = node.get('title');
-            if (node.get('title') !== this.get('nodeTitle')) {
-                node.set('title', this.get('nodeTitle'));
+            if (node.get('title') !== this.get('title')) {
+                node.set('title', this.get('title'));
                 node.save()
                 .then(() => {
                     this.send('upload');

--- a/app/components/preprint-form-project-select.js
+++ b/app/components/preprint-form-project-select.js
@@ -30,7 +30,7 @@ import {stripDiacritics} from 'ember-power-select/utils/group-utils';
  *     startState=_State.START
  *     existingState=existingState
  *     _existingState=_existingState
- *     nodeTitle=nodeTitle
+ *     title=title
  *     currentUser=user
  *     selectedFile=selectedFile
  *     hasFile=hasFile

--- a/app/components/preprint-title-editor.js
+++ b/app/components/preprint-title-editor.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import { validator, buildValidations } from 'ember-cp-validations';
 
 const TitleValidation = buildValidations({
-    nodeTitle: {
+    title: {
         description: 'Title',
         validators: [
             validator('presence', true),
@@ -20,12 +20,12 @@ const TitleValidation = buildValidations({
  */
 
 /**
- * Preprint-title-editor widget - allows you to add a title if none exists, or edit existing title. Adds validation. Will modify nodeTitle and titleValid.
+ * Preprint-title-editor widget - allows you to add a title if none exists, or edit existing title. Adds validation. Will modify title and titleValid.
  *
  * Sample usage:
  * ```handlebars
  * {{preprint-title-editor
- *  nodeTitle=nodeTitle
+ *  title=title
  *  titlePlaceholder=titlePlaceholder
  *  titleValid=titleValid
 }}
@@ -34,10 +34,10 @@ const TitleValidation = buildValidations({
  */
 
 export default Ember.Component.extend(TitleValidation, {
-    nodeTitle: null,
+    title: null,
     titlePlaceholder: 'Enter preprint title',
-    isValid: Ember.observer('nodeTitle', function() {
-        if (this.get('nodeTitle') && this.get('validations.isValid')) {
+    isValid: Ember.observer('title', function() {
+        if (this.get('title') && this.get('validations.isValid')) {
             this.set('titleValid', true);
         } else {
             this.set('titleValid', false);

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -137,12 +137,12 @@ export default Ember.Controller.extend(Analytics, {
         return `https://www.facebook.com/dialog/share?${queryStringify(queryParams)}`;
     }),
     // https://developer.linkedin.com/docs/share-on-linkedin
-    linkedinHref: Ember.computed('node', function() {
+    linkedinHref: Ember.computed('model', function() {
         const queryParams = {
             url: [window.location.href, 1024],          // required
             mini: ['true', 4],                          // required
-            title: [this.get('node.title'), 200],      // optional
-            summary: [this.get('node.description'), 256], // optional
+            title: [this.get('model.title'), 200],      // optional
+            summary: [this.get('model.description'), 256], // optional
             source: ['Open Science Framework', 200]     // optional
         };
 
@@ -165,7 +165,7 @@ export default Ember.Controller.extend(Analytics, {
         return this.get('model.subjects').reduce((acc, val) => acc.concat(val), []).uniqBy('id');
     }),
 
-    hasTag: Ember.computed.bool('node.tags.length'),
+    hasTag: Ember.computed.bool('model.tags.length'),
 
     authors: Ember.computed('model', function() {
         // Cannot be called until node has loaded!
@@ -187,8 +187,8 @@ export default Ember.Controller.extend(Analytics, {
             .replace(/({{copyrightHolders}})/g, copyright_holders.join(', '));
     }),
 
-    hasShortenedDescription: Ember.computed('node.description', function() {
-        const nodeDescription = this.get('node.description');
+    hasShortenedDescription: Ember.computed('model.description', function() {
+        const nodeDescription = this.get('model.description');
 
         return nodeDescription && nodeDescription.length > 350;
     }),
@@ -197,10 +197,10 @@ export default Ember.Controller.extend(Analytics, {
         return this.get('hasShortenedDescription') && !this.get('expandedAbstract');
     }),
 
-    description: Ember.computed('node.description', function() {
+    description: Ember.computed('model.description', function() {
         // Get a shortened version of the abstract, but doesn't cut in the middle of word by going
         // to the last space.
-        return this.get('node.description')
+        return this.get('model.description')
             .slice(0, 350)
             .replace(/\s+\S*$/, '');
     }),

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -188,9 +188,9 @@ export default Ember.Controller.extend(Analytics, {
     }),
 
     hasShortenedDescription: Ember.computed('model.description', function() {
-        const nodeDescription = this.get('model.description');
+        const description = this.get('model.description');
 
-        return nodeDescription && nodeDescription.length > 350;
+        return description && description.length > 350;
     }),
 
     useShortenedDescription: Ember.computed('expandedAbstract', 'hasShortenedDescription', function() {

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -115,10 +115,10 @@ export default Ember.Controller.extend(Analytics, {
         );
     }),
 
-    twitterHref: Ember.computed('node', function() {
+    twitterHref: Ember.computed('model', function() {
         const queryParams = {
             url: window.location.href,
-            text: this.get('node.title'),
+            text: this.get('model.title'),
             via: 'OSFramework'
         };
         return `https://twitter.com/intent/tweet?${queryStringify(queryParams)}`;
@@ -148,9 +148,9 @@ export default Ember.Controller.extend(Analytics, {
 
         return `https://www.linkedin.com/shareArticle?${queryStringify(queryParams)}`;
     }),
-    emailHref: Ember.computed('node', function() {
+    emailHref: Ember.computed('model', function() {
         const queryParams = {
-            subject: this.get('node.title'),
+            subject: this.get('model.title'),
             body: window.location.href
         };
 
@@ -167,17 +167,13 @@ export default Ember.Controller.extend(Analytics, {
 
     hasTag: Ember.computed.bool('node.tags.length'),
 
-    authors: Ember.computed('node', function() {
+    authors: Ember.computed('model', function() {
         // Cannot be called until node has loaded!
-        const node = this.get('node');
-
-        if (!node)
-            return [];
-
+        const model = this.get('model');
         const contributors = Ember.A();
 
         return DS.PromiseArray.create({
-            promise: loadAll(node, 'contributors', contributors)
+            promise: loadAll(model, 'contributors', contributors)
                 .then(() => contributors)
         });
     }),

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -160,7 +160,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     file: null, // Preuploaded file - file that has been dragged to dropzone, but not uploaded to node.
     selectedFile: null, // File that will be the preprint (already uploaded to node or selected from existing node)
     contributors: Ember.A(), // Contributors on preprint - if creating a component, contributors will be copied over from parent
-    nodeTitle: null, // Preprint title
+    title: null, // Preprint title
     nodeLocked: false, // IMPORTANT PROPERTY. After advancing beyond Step 1: Upload on Add Preprint form, the node is locked.  Is True on Edit.
     searchResults: [], // List of users matching search query
     savingPreprint: false, // True when Share button is pressed on Add Preprint page
@@ -210,7 +210,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             file: null,
             selectedFile: null,
             contributors: Ember.A(),
-            nodeTitle: null,
+            title: null,
             nodeLocked: false, // Will be set to true if edit?
             searchResults: [],
             savingPreprint: false,
@@ -247,7 +247,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     ///////////////////////////////////////
     // Validation rules and changed states for form sections
 
-    // In order to advance from upload state, node and selectedFile must have been defined, and nodeTitle must be set.
+    // In order to advance from upload state, node and selectedFile must have been defined, and title must be set.
     uploadValid: Ember.computed.alias('nodeLocked'), // Once the node has been locked (happens in step one of upload section), users are free to navigate through form unrestricted
     abstractValid: Ember.computed.alias('validations.attrs.basicsAbstract.isValid'),
     doiValid: Ember.computed.alias('validations.attrs.basicsDOI.isValid'),
@@ -295,8 +295,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     }),
 
     // Does the pending title differ from the title already saved?
-    titleChanged: Ember.computed('model.title', 'nodeTitle', function() {
-        return this.get('model.title') !== this.get('nodeTitle');
+    titleChanged: Ember.computed('model.title', 'title', function() {
+        return this.get('model.title') !== this.get('title');
     }),
 
     // Are there any unsaved changes in the upload section?
@@ -326,13 +326,13 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     // Does the list of pending tags differ from the saved tags in the db?
     tagsChanged: Ember.computed('basicsTags.@each', 'model.tags', function() {
         const basicsTags = this.get('basicsTags');
-        const nodeTags = this.get('model.tags');
+        const tags = this.get('model.tags');
 
-        return basicsTags && nodeTags &&
+        return basicsTags && tags &&
             (
-                basicsTags.length !== nodeTags.length ||
+                basicsTags.length !== tags.length ||
                 basicsTags.some(
-                    (v, i) => fixSpecialChar(v) !== fixSpecialChar(nodeTags[i])
+                    (v, i) => fixSpecialChar(v) !== fixSpecialChar(tags[i])
                 )
             );
     }),
@@ -630,14 +630,14 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
 
             const model = this.get('model');
             const currentTitle = model.get('title');
-            const nodeTitle = this.get('nodeTitle');
+            const title = this.get('title');
 
             this.set('basicsAbstract', this.get('node.description') || null);
 
             return Promise.resolve()
                 .then(() => {
-                    if (currentTitle !== nodeTitle)
-                        model.set('title', nodeTitle);
+                    if (currentTitle !== title)
+                        model.set('title', title);
                 })
                 .then(() => this.send(this.get('abandonedPreprint') ? 'resumeAbandonedPreprint' : 'startPreprint'))
                 .catch(() => {
@@ -656,7 +656,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     action: 'click',
                     label: 'Submit - Save and Continue, New Component, Copy File'
                 });
-            node.addChild(this.get('nodeTitle'))
+            node.addChild(this.get('title'))
                 .then(child => {
                     this.set('parentNode', node);
                     this.set('node', child);
@@ -748,7 +748,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             this.setProperties({
                 file: null,
                 selectedFile: this.get('store').peekRecord('file', this.get('model.primaryFile.id')),
-                nodeTitle: this.get('model.title'),
+                title: this.get('model.title'),
                 titleValid: true,
             });
         },
@@ -770,7 +770,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                 case 'belowFile':
                     props.push('convertOrCopy');
                 case 'belowConvertOrCopy':
-                    props.push('nodeTitle');
+                    props.push('title');
                     break;
             }
 

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -266,7 +266,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     disciplineValid: Ember.computed.notEmpty('subjectsList'),
 
     // Does node have a saved title?
-    savedTitle: Ember.computed.notEmpty('node.title'),
+    savedTitle: Ember.computed.notEmpty('model.title'),
 
     // Does preprint have a saved primaryFile?
     savedFile: Ember.computed.notEmpty('model.primaryFile.content'),
@@ -295,8 +295,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     }),
 
     // Does the pending title differ from the title already saved?
-    titleChanged: Ember.computed('node.title', 'nodeTitle', function() {
-        return this.get('node.title') !== this.get('nodeTitle');
+    titleChanged: Ember.computed('model.title', 'nodeTitle', function() {
+        return this.get('model.title') !== this.get('nodeTitle');
     }),
 
     // Are there any unsaved changes in the upload section?
@@ -630,24 +630,19 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     label: 'Submit - Save and Continue, Existing Node Existing File'
                 });
 
-            const node = this.get('node');
-            const currentTitle = node.get('title');
+            const model = this.get('model');
+            const currentTitle = model.get('title');
             const nodeTitle = this.get('nodeTitle');
 
             this.set('basicsAbstract', this.get('node.description') || null);
 
             return Promise.resolve()
                 .then(() => {
-                    if (currentTitle === nodeTitle) {
-                        return;
-                    }
-
-                    node.set('title', nodeTitle);
-                    return node.save();
+                    if (currentTitle !== nodeTitle)
+                        model.set('title', nodeTitle);
                 })
                 .then(() => this.send(this.get('abandonedPreprint') ? 'resumeAbandonedPreprint' : 'startPreprint'))
                 .catch(() => {
-                    node.set('title', currentTitle);
                     this.get('toast').error(
                         this.get('i18n').t('submit.could_not_update_title')
                     );
@@ -755,7 +750,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             this.setProperties({
                 file: null,
                 selectedFile: this.get('store').peekRecord('file', this.get('model.primaryFile.id')),
-                nodeTitle: this.get('node.title'),
+                nodeTitle: this.get('model.title'),
                 titleValid: true,
             });
         },
@@ -1092,9 +1087,9 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
 
             let save_changes = null;
             if (submitAction) {
-                save_changes = model.save().then(() => node.save()).then(() => submitAction.save());
+                save_changes = model.save().then(() => submitAction.save());
             } else {
-                save_changes = model.save().then(() => node.save());
+                save_changes = model.save();
             }
 
             return save_changes

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -272,7 +272,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     savedFile: Ember.computed.notEmpty('model.primaryFile.content'),
 
     // Does node have a saved description?
-    savedAbstract: Ember.computed.notEmpty('node.description'),
+    savedAbstract: Ember.computed.notEmpty('model.description'),
 
     // Does preprint have saved subjects?
     savedSubjects: Ember.computed.notEmpty('model.subjects'),
@@ -307,28 +307,26 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     ////////////////////////////////////////////////////
 
     // Pending abstract
-    basicsAbstract:  Ember.computed('node.description', function() {
-        let node = this.get('node');
-        return node ? node.get('description') : null;
+    basicsAbstract:  Ember.computed('model.description', function() {
+        return this.get('model.description') || null;
     }),
 
     // Does the pending abstract differ from the saved abstract in the db?
-    abstractChanged: Ember.computed('basicsAbstract', 'node.description', function() {
+    abstractChanged: Ember.computed('basicsAbstract', 'model.description', function() {
         let basicsAbstract = this.get('basicsAbstract');
-        return basicsAbstract !== null && basicsAbstract.trim() !== this.get('node.description');
+        return basicsAbstract !== null && basicsAbstract.trim() !== this.get('model.description');
     }),
 
     // Pending tags
-    basicsTags: Ember.computed('node', function() {
-        const node = this.get('node');
-
-        return node ? node.get('tags').map(fixSpecialChar) : Ember.A();
+    basicsTags: Ember.computed('model.tags', function() {
+        let tags = this.get('model.tags');
+        return (tags && tags.map(fixSpecialChar)) || Ember.A();
     }),
 
     // Does the list of pending tags differ from the saved tags in the db?
-    tagsChanged: Ember.computed('basicsTags.@each', 'node.tags', function() {
+    tagsChanged: Ember.computed('basicsTags.@each', 'model.tags', function() {
         const basicsTags = this.get('basicsTags');
-        const nodeTags = this.get('node.tags');
+        const nodeTags = this.get('model.tags');
 
         return basicsTags && nodeTags &&
             (
@@ -794,8 +792,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     action: 'click',
                     label: `${this.get('editMode') ? 'Edit' : 'Submit'} - Discard Basics Changes`
                 });
-            this.set('basicsTags', this.get('node.tags').slice(0).map(fixSpecialChar));
-            this.set('basicsAbstract', this.get('node.description'));
+            this.set('basicsTags', this.get('model.tags').slice(0).map(fixSpecialChar));
+            this.set('basicsAbstract', this.get('model.description'));
             this.set('basicsDOI', this.get('model.doi'));
             this.set('basicsOriginalPublicationDate', this.get('model.originalPublicationDate'));
             let date = new Date();
@@ -836,8 +834,8 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             const node = this.get('node');
             const model = this.get('model');
             // Saves off current server-state basics fields, so UI can be restored in case of failure
-            const currentAbstract = node.get('description');
-            const currentTags = node.get('tags').slice();
+            const currentAbstract = model.get('description');
+            const currentTags = model.get('tags').slice();
             const currentDOI = model.get('doi');
             const currentOriginalPublicationDate = model.get('originalPublicationDate');
             const currentLicenseType = model.get('license');
@@ -849,10 +847,10 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                 .map(item => item.trim());
 
             if (this.get('abstractChanged'))
-                node.set('description', this.get('basicsAbstract'));
+                model.set('description', this.get('basicsAbstract'));
 
             if (this.get('tagsChanged'))
-                node.set('tags', this.get('basicsTags'));
+                model.set('tags', this.get('basicsTags'));
 
             if (this.get('applyLicense')) {
                 if (node.get('nodeLicense.year') !== this.get('basicsLicense.year') || (node.get('nodeLicense.copyrightHolders') || []).join() !== copyrightHolders.join()) {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -638,8 +638,9 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
 
             return Promise.resolve()
                 .then(() => {
-                    if (currentTitle !== title)
+                    if (currentTitle !== title) {
                         model.set('title', title);
+                    }
                 })
                 .then(() => this.send(this.get('abandonedPreprint') ? 'resumeAbandonedPreprint' : 'startPreprint'))
                 .catch(() => {

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -62,7 +62,7 @@ export default Ember.Mixin.create({
         controller.set('filePickerState', 'existing'); // In edit mode, dealing with existing project
         controller.set('existingState', 'new'); // In edit mode, only option to change file is to upload a NEW file
         controller.set('node', node);
-        controller.set('nodeTitle', node.get('title'));
+        controller.set('title', node.get('title'));
         controller.set('nodeLocked', true);
         controller.set('titleValid', true);
         model.get('primaryFile').then((file) => {

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -83,9 +83,9 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     loadAll(node, 'contributors', contributors, { filter: { bibliographic: true } })
                 ]);
             })
-            .then(([provider, node, license]) => {
-                const title = node.get('title');
-                const description = node.get('description');
+            .then(([provider, license]) => {
+                const title = preprint.get('title');
+                const description = preprint.get('description');
                 const mintDoi = extractDoiFromString(preprint.get('preprintDoiUrl'));
                 const peerDoi = preprint.get('doi');
                 const doi = peerDoi ? peerDoi : mintDoi;
@@ -160,7 +160,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
 
                 const tags = [
                     ...preprint.get('subjects').map(subjectBlock => subjectBlock.map(subject => subject.text)),
-                    ...node.get('tags')
+                    ...preprint.get('tags')
                 ];
 
                 for (const tag of tags) {

--- a/app/templates/components/file-uploader.hbs
+++ b/app/templates/components/file-uploader.hbs
@@ -11,7 +11,7 @@
     }}
     {{#if hasFile}}
         <form onchange={{action 'track' 'input' 'onchange' 'Submit - Add title, Upload new preprint'}}>
-            {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid pressSubmit=(action 'setNodeAndFile')}}
+            {{preprint-title-editor title=title titleValid=titleValid pressSubmit=(action 'setNodeAndFile')}}
         </form>
     {{/if}}
 
@@ -54,11 +54,11 @@
     {{#if (and selectedNode (or hasFile osfFile)) use='crossFade'}}
         {{#if nodeLocked}}
             {{#preprint-form-section editMode=editMode class="upload-section-block bottom-title-underline" allowOpen=true name='titleOfPreprint' open=false}} {{!EDIT MODE - UPDATE TITLE/SAVE CHANGES SECTION}}
-                {{preprint-form-header nodeTitle=nodeTitle name='title_of_preprint' showValidationIndicator=false}}
+                {{preprint-form-header title=title name='title_of_preprint' showValidationIndicator=false}}
                 {{#preprint-form-body}}
                     <label class="text-muted title-label text-smaller">  {{if isTopLevelNode (t "components.preprint-form-project-select.edit_preprint_title_project") (t "components.preprint-form-project-select.edit_preprint_title_component")}} </label>
                     <form onchange={{if editMode (action 'track' 'input' 'onchange' 'Edit - Edit title') (action 'track' 'input' 'onchange' 'Submit - Edit title')}}>
-                        {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid pressSubmit=(action 'uploadFileToExistingNode')}}
+                        {{preprint-title-editor title=title titleValid=titleValid pressSubmit=(action 'uploadFileToExistingNode')}}
                     </form>
                 {{/preprint-form-body}}
             {{/preprint-form-section}}
@@ -71,12 +71,12 @@
             {{#preprint-form-section class="upload-section-block" allowOpen=true name='organize' open=false}} {{!ORGANIZE DECISION SECTION}}
                 {{preprint-form-header name='organize' isTopLevelNode=isTopLevelNode convertOrCopy=convertOrCopy showValidationIndicator=false}}
                 {{#preprint-form-body}}
-                    {{convert-or-copy-project nextUploadSection=nextUploadSection clearDownstreamFields=clearDownstreamFields isTopLevelNode=isTopLevelNode convertOrCopy=convertOrCopy nodeTitle=nodeTitle node=node titleValid=titleValid convertProjectConfirmed=convertProjectConfirmed}}
+                    {{convert-or-copy-project nextUploadSection=nextUploadSection clearDownstreamFields=clearDownstreamFields isTopLevelNode=isTopLevelNode convertOrCopy=convertOrCopy title=title node=node titleValid=titleValid convertProjectConfirmed=convertProjectConfirmed}}
                 {{/preprint-form-body}}
             {{/preprint-form-section}}
             {{#if (or (eq convertOrCopy 'copy') (and (eq convertOrCopy 'convert') convertProjectConfirmed)) use='crossFade'}}
                 {{#preprint-form-section class="upload-section-block" allowOpen=true name='finalizeUpload' open=false}} {{!FINALIZE UPLOAD SECTION - NEW FILE}}
-                    {{preprint-form-header name='finalize_upload' nodeTitle=nodeTitle showValidationIndicator=false}}
+                    {{preprint-form-header name='finalize_upload' title=title showValidationIndicator=false}}
                     {{#preprint-form-body}}
                         {{#if (eq convertOrCopy 'convert')}}
                             {{#if convertProjectConfirmed}}
@@ -84,7 +84,7 @@
                             {{/if}}
                         {{/if}}
                         <form onchange={{action 'track' 'input' 'onchange' 'Submit - Add title, Connect preprint to existing project'}}>
-                            {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid pressSubmit=(action 'setNodeAndFile')}}
+                            {{preprint-title-editor title=title titleValid=titleValid pressSubmit=(action 'setNodeAndFile')}}
                         </form>
 
                         <div class="row text-center m-v-md">

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -121,14 +121,14 @@
         {{/if}}
 
         {{#if (eq name 'finalize_upload')}}
-            {{#if nodeTitle}}
-                 <p>{{t "components.preprint-form-header.title"}}: {{nodeTitle}} </p>
+            {{#if title}}
+                 <p>{{t "components.preprint-form-header.title"}}: {{title}} </p>
             {{/if}}
         {{/if}}
 
         {{#if (eq name 'title_of_preprint')}}
-            {{#if nodeTitle}}
-                 <p> {{nodeTitle}} </p>
+            {{#if title}}
+                 <p> {{title}} </p>
             {{/if}}
         {{/if}}
 

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -79,12 +79,12 @@
                             {{#preprint-form-section class="upload-section-block" allowOpen=true name='organize' open=false}} {{!ORGANIZE DECISION SECTION}}
                                 {{preprint-form-header isTopLevelNode=isTopLevelNode convertOrCopy=convertOrCopy name='organize' showValidationIndicator=false}}
                                 {{#preprint-form-body}}
-                                    {{convert-or-copy-project nextUploadSection=nextUploadSection clearDownstreamFields=clearDownstreamFields nodeTitle=nodeTitle node=node isTopLevelNode=isTopLevelNode titleValid=titleValid convertProjectConfirmed=convertProjectConfirmed convertOrCopy=convertOrCopy}}
+                                    {{convert-or-copy-project nextUploadSection=nextUploadSection clearDownstreamFields=clearDownstreamFields title=title node=node isTopLevelNode=isTopLevelNode titleValid=titleValid convertProjectConfirmed=convertProjectConfirmed convertOrCopy=convertOrCopy}}
                                 {{/preprint-form-body}}
                             {{/preprint-form-section}}
                             {{#if (or (eq convertOrCopy 'copy') (and (eq convertOrCopy 'convert') convertProjectConfirmed)) use='crossFade'}}
                                 {{#preprint-form-section class="upload-section-block" allowOpen=true name='finalizeUpload' open=false}} {{!FINALIZE UPLOAD SECTION - EXISTING FILE}}
-                                    {{preprint-form-header nodeTitle=nodeTitle name='finalize_upload' showValidationIndicator=false}}
+                                    {{preprint-form-header title=title name='finalize_upload' showValidationIndicator=false}}
                                     {{#preprint-form-body}}
                                         {{#if (eq convertOrCopy 'convert')}}
                                             {{#if convertProjectConfirmed}}
@@ -92,7 +92,7 @@
                                             {{/if}}
                                         {{/if}}
                                         <form onchange={{action 'track' 'input' 'onchange' 'Submit - Add title, Connect preprint to existing project'}}>
-                                            {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid pressSubmit=(action (if (eq convertOrCopy 'convert') existingNodeExistingFile createComponentCopyFile) name)}}
+                                            {{preprint-title-editor title=title titleValid=titleValid pressSubmit=(action (if (eq convertOrCopy 'convert') existingNodeExistingFile createComponentCopyFile) name)}}
                                         </form>
                                         <div class="text-center m-v-md">
                                             <p> {{t "components.preprint-form-project-select.initiate_preprint_process"}} </p>
@@ -113,7 +113,7 @@
                     finishUpload=finishUpload
                     startPreprint=startPreprint
                     startState=startState
-                    nodeTitle=nodeTitle
+                    title=title
                     currentUser=currentUser
                     osfFile=selectedFile
                     hasFile=hasFile

--- a/app/templates/components/preprint-title-editor.hbs
+++ b/app/templates/components/preprint-title-editor.hbs
@@ -1,1 +1,1 @@
-{{validated-input model=this valuePath='nodeTitle' placeholder=(t "components.file-uploader.title_placeholder") value=nodeTitle pressSubmit=pressSubmit}}
+{{validated-input model=this valuePath='title' placeholder=(t "components.file-uploader.title_placeholder") value=title pressSubmit=pressSubmit}}

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -83,7 +83,7 @@
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
                         <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
-                            {{~if useShortenedDescription description node.description~}}
+                            {{~if useShortenedDescription description model.description~}}
                         </p>
                         <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
                             {{~t (if expandedAbstract 'content.see_less' 'content.see_more')~}}
@@ -141,7 +141,7 @@
                     <div class="p-t-xs">
                         <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
                         {{#if hasTag}}
-                            {{#each node.tags as |tag|}}
+                            {{#each model.tags as |tag|}}
                                 <span class="badge">{{fix-special-char tag}}</span>
                             {{/each}}
                         {{else}}

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -1,11 +1,11 @@
-{{title node.title}}
+{{title model.title}}
 
 <div id="view-page">
     <div class="p-t-xl p-b-md m-b-md dark-overlay-header-background header-row">{{!HEADER ROW}}
         <div class="container">{{!CONTAINER DIV}}
             <div class="row">
                 <div class="col-xs-12 col-sm-10">
-                    <h1 id="preprintTitle" class="p-b-md">{{node.title}}</h1>
+                    <h1 id="preprintTitle" class="p-b-md">{{model.title}}</h1>
                     <h5 class="view-authors">
                         <ul class="comma-list">
                             {{#if authors}}
@@ -59,7 +59,7 @@
                 {{else}}
                     {{#if (not node.public)}}
                         <div class="alert alert-danger m-r-md" role="alert">
-                            {{t "content.private_preprint_warning"}} <a href={{node.links.html}}>{{node.title}} </a> {{t "content.public"}}.
+                            {{t "content.private_preprint_warning"}} <a href={{node.links.html}}>{{model.title}} </a> {{t "content.public"}}.
                         </div>
                     {{/if}}
                     {{supplementary-file-browser chosenFile=chosenFile preprint=model node=node projectURL=node.links.html chooseFile=(action 'chooseFile') dualTrackNonContributors=(action 'dualTrackNonContributors')}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -136,7 +136,7 @@
 
                     {{#with _names.[2] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=node.tags abstract=node.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
+                            {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=model.tags abstract=model.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class='row'>
                                     <div class='col-xs-12'>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -45,7 +45,7 @@
                                                 startState=_State.START
                                                 existingState=existingState
                                                 _existingState=_existingState
-                                                nodeTitle=nodeTitle
+                                                title=title
                                                 currentUser=user
                                                 osfFile=selectedFile
                                                 hasFile=hasFile
@@ -81,7 +81,7 @@
                                               startState=_State.START
                                               existingState=existingState
                                               _existingState=_existingState
-                                              nodeTitle=nodeTitle
+                                              title=title
                                               currentUser=user
                                               selectedFile=selectedFile
                                               hasFile=hasFile

--- a/tests/integration/components/convert-or-copy-project-test.js
+++ b/tests/integration/components/convert-or-copy-project-test.js
@@ -18,7 +18,7 @@ test('it renders', function(assert) {
     assert.equal(this.$('#convertExistingOrCreateComponent label').first().text().trim(), 'Make a new component');
 });
 
-test('choosing copy changes mode to copy', function(assert){
+test('choosing copy changes mode to copy', function(assert) {
     this.set('convertOrCopy', null);
 
     this.render(hbs`{{convert-or-copy-project
@@ -32,7 +32,7 @@ test('choosing copy changes mode to copy', function(assert){
     assert.equal(this.get('convertOrCopy'), 'copy');
 });
 
-test('choosing copy makes the preprint title null and requires a title change', function(assert){
+test('choosing copy makes the preprint title null and requires a title change', function(assert) {
     this.set('title', 'Como nossos pais');
     this.set('titleValid', true);
 
@@ -48,7 +48,7 @@ test('choosing copy makes the preprint title null and requires a title change', 
     assert.equal(this.get('title'), null);
 });
 
-test('choosing convert displays converting options and changes mode to convert', function(assert){
+test('choosing convert displays converting options and changes mode to convert', function(assert) {
     this.set('convertOrCopy', null);
 
     this.render(hbs`{{convert-or-copy-project
@@ -66,7 +66,7 @@ test('choosing convert displays converting options and changes mode to convert',
     assert.ok(this.$('.exclamation-confirm-convert').length);
 });
 
-test('choosing convert makes the preprint title the title of the node about to be converted and does not require change', function(assert){
+test('choosing convert makes the preprint title the title of the node about to be converted and does not require change', function(assert) {
     this.set('title', null);
     this.set('titleValid', null);
     this.set('node', {
@@ -85,7 +85,7 @@ test('choosing convert makes the preprint title the title of the node about to b
     assert.equal(this.get('title'), 'Mas, que Nada!');
 });
 
-test('can confirm conversion and passes the convertProjectConfirmed flag up', function(assert){
+test('can confirm conversion and passes the convertProjectConfirmed flag up', function(assert) {
     this.set('convertProjectConfirmed', false);
 
     this.render(hbs`{{convert-or-copy-project

--- a/tests/integration/components/convert-or-copy-project-test.js
+++ b/tests/integration/components/convert-or-copy-project-test.js
@@ -32,20 +32,20 @@ skip('choosing copy changes mode to copy', function(assert){
     assert.equal(this.get('convertOrCopy'), 'copy');
 });
 
-skip('choosing copy makes nodeTitle null and requires a title change', function(assert){
-    this.set('nodeTitle', 'Como nossos pais');
+skip('choosing copy makes title null and requires a title change', function(assert){
+    this.set('title', 'Como nossos pais');
     this.set('titleValid', true);
 
     this.render(hbs`{{convert-or-copy-project
         clearDownstreamFields=(action noop)
         nextUploadSection=(action noop)
-        nodeTitle=nodeTitle titleValid=titleValid
+        title=title titleValid=titleValid
     }}`);
 
     this.$('#copy').click();
 
     assert.ok(!this.get('titleValid'));
-    assert.equal(this.get('nodeTitle'), null);
+    assert.equal(this.get('title'), null);
 });
 
 skip('choosing convert displays converting options and changes mode to convert', function(assert){
@@ -66,8 +66,8 @@ skip('choosing convert displays converting options and changes mode to convert',
     assert.ok(this.$('.exclamation-confirm-convert').length);
 });
 
-skip('choosing convert makes nodeTitle the title of the node about to be converted and does not require change', function(assert){
-    this.set('nodeTitle', null);
+skip('choosing convert makes title the title of the node about to be converted and does not require change', function(assert){
+    this.set('title', null);
     this.set('titleValid', null);
     this.set('node', {
         title: 'Mas, que Nada!'
@@ -76,13 +76,13 @@ skip('choosing convert makes nodeTitle the title of the node about to be convert
     this.render(hbs`{{convert-or-copy-project
         clearDownstreamFields=(action noop)
         nextUploadSection=(action noop)
-        node=node nodeTitle=nodeTitle titleValid=titleValid
+        node=node title=title titleValid=titleValid
     }}`);
 
     this.$('#convert').click();
 
     assert.ok(this.get('titleValid'));
-    assert.equal(this.get('nodeTitle'), 'Mas, que Nada!');
+    assert.equal(this.get('title'), 'Mas, que Nada!');
 });
 
 skip('can confirm conversion and passes the convertProjectConfirmed flag up', function(assert){

--- a/tests/integration/components/preprint-title-editor-test.js
+++ b/tests/integration/components/preprint-title-editor-test.js
@@ -14,19 +14,19 @@ function render(context, componentArgs) {
 //cursory glance at ember-cpi-validations seem to indicate trouble with testing
 
 test('renders valid title', function(assert) {
-    render(this, 'nodeTitle="This is a valid title"');
+    render(this, 'title="This is a valid title"');
     assert.ok(!this.$('.error').length);
 });
 
 test('renders no title', function(assert) {
     this.set('title', 'Valid Title');
-    render(this, 'nodeTitle=title');
+    render(this, 'title=title');
     //Need to go from actual input to no input to trigger validation
     this.set('title', '');
     assert.ok(this.$('.error').length);
 });
 
 test('renders invalid title', function(assert) {
-    render(this, `nodeTitle='${'Title is too long'.repeat(250)}'`);
+    render(this, `title='${'Title is too long'.repeat(250)}'`);
     assert.ok(this.$('.error').length);
 });

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -69,11 +69,11 @@ test('twitterHref computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'test title'
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         const location = encodeURIComponent(window.location.href);
 
@@ -126,11 +126,11 @@ test('emailHref computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'test title'
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         const location = encodeURIComponent(window.location.href);
 

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -103,12 +103,12 @@ test('linkedinHref computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'test title',
             description: 'test description'
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         const location = encodeURIComponent(window.location.href);
 
@@ -148,11 +148,11 @@ test('hasTag computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             tags: []
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         assert.strictEqual(
             ctrl.get('hasTag'),
@@ -161,11 +161,11 @@ test('hasTag computed property', function (assert) {
     });
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             tags: ['a', 'b', 'c']
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         assert.strictEqual(
             ctrl.get('hasTag'),
@@ -183,13 +183,11 @@ skip('authors computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             id: 'abc12'
         });
 
-        ctrl.setProperties({
-            node
-        });
+        ctrl.set('model', preprint);
 
         // TODO figure out how to test with at least one contributor
         ctrl.get('authors')
@@ -293,11 +291,10 @@ test('hasShortenedDescription computed property', function (assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             description: 'Lorem ipsum'
         });
-
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         assert.strictEqual(
             ctrl.get('hasShortenedDescription'),
@@ -306,11 +303,11 @@ test('hasShortenedDescription computed property', function (assert) {
     });
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             description: 'Lorem ipsum'.repeat(35)
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         assert.strictEqual(
             ctrl.get('hasShortenedDescription'),
@@ -349,11 +346,11 @@ test('description computed property', function (assert) {
         const input = 'Lorem ipsum dolor sit amet, atqui elitr id vim, at clita facilis tibique ius, ad pro stet accusam. Laudem essent commune ea vix. Duis hendrerit complectitur usu eu, ei nam ullum accusamus inciderint, has appetere assueverit te. An pro maiorum alienum voluptatibus, mei adhuc docendi prodesset in. Ut vel mundi atomorum quaerendum, cu per autem menandri consequat, tantas dictas quodsi nec eu. Ornatus forensibus vituperatoribus id vix.';
         const expected ='Lorem ipsum dolor sit amet, atqui elitr id vim, at clita facilis tibique ius, ad pro stet accusam. Laudem essent commune ea vix. Duis hendrerit complectitur usu eu, ei nam ullum accusamus inciderint, has appetere assueverit te. An pro maiorum alienum voluptatibus, mei adhuc docendi prodesset in. Ut vel mundi atomorum quaerendum, cu per autem';
 
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             description: input
         });
 
-        ctrl.setProperties({node});
+        ctrl.set('model', preprint);
 
         assert.strictEqual(
             ctrl.get('description'),

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -259,13 +259,13 @@ test('savedAbstract computed property', function(assert) {
     const store = this.store;
     const ctrl = this.subject();
     Ember.run(() => {
-        const node = store.createRecord('node', {});
-        const nodeWithDescription = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {});
+        const preprintWithDescription = store.createRecord('preprint', {
             'description': 'The Best Description'
         });
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         assert.equal(ctrl.get('savedAbstract'), false);
-        ctrl.set('node', nodeWithDescription);
+        ctrl.set('model', preprintWithDescription);
         assert.equal(ctrl.get('savedAbstract'), true);
         Ember.run.cancelTimers();
     });
@@ -361,10 +361,10 @@ test('basicsAbstract computed property', function(assert) {
     this.inject.service('store');
     const store = this.store;
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             'description': 'A great abstract'
         });
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         assert.equal(ctrl.get('basicsAbstract'), 'A great abstract');
         Ember.run.cancelTimers();
     });
@@ -376,12 +376,12 @@ test('abstractChanged computed property', function(assert) {
     this.inject.service('store');
     const store = this.store;
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const model = store.createRecord('preprint', {
             'description': 'A great abstract'
         });
-        ctrl.set('node', node);
+        ctrl.set('model', model);
         assert.equal(ctrl.get('abstractChanged'), true);
-        node.set('description', 'Abstract with whitespace');
+        model.set('description', 'Abstract with whitespace');
         assert.equal(ctrl.get('abstractChanged'), false);
     });
 });
@@ -391,11 +391,11 @@ test('basicsTags computed property', function(assert) {
     this.inject.service('store');
     const store = this.store;
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             'tags': ['firstTag', 'secondTag']
         });
         assert.equal(ctrl.get('basicsTags').length, 0);
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         assert.equal(ctrl.get('basicsTags').length, 2);
     });
 });
@@ -406,11 +406,11 @@ test('tagsChanged computed property', function(assert) {
     const store = this.store;
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             'tags': ['firstTag', 'secondTag']
         });
 
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         assert.equal(ctrl.get('tagsChanged'), false);
 
         ctrl.get('basicsTags').pushObject('newTag');
@@ -577,10 +577,8 @@ test('discardBasics properly joins copyrightHolders', function(assert) {
     this.inject.service('store');
     const store = this.store;
     Ember.run(() => {
-        const node =  store.createRecord('node', {
-            tags: ['tags']
-        });
         const model = store.createRecord('preprint', {
+            tags: ['tags'],
             licenseRecord: {
                 copyright_holders: ['Frank', 'Everest']
             }
@@ -589,7 +587,6 @@ test('discardBasics properly joins copyrightHolders', function(assert) {
             'name': 'No license'
         });
         model.set('license', license);
-        ctrl.set('node', node);
         ctrl.set('model', model);
         ctrl.send('discardBasics');
         return wait().then(() => assert.equal(ctrl.get('basicsLicense').copyrightHolders, 'Frank, Everest'));
@@ -866,11 +863,11 @@ test('clearDownstreamFields action - belowConvertOrCopy', function(assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello'
         });
 
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
@@ -878,7 +875,7 @@ test('clearDownstreamFields action - belowConvertOrCopy', function(assert) {
 
         ctrl.send('clearDownstreamFields', 'belowConvertOrCopy');
 
-        assert.equal(ctrl.get('node'), node);
+        assert.equal(ctrl.get('model'), preprint);
         assert.equal(ctrl.get('selectedFile'), 'Test file');
         assert.equal(ctrl.get('file'), 'file');
         assert.equal(ctrl.get('convertOrCopy'), 'copy');
@@ -893,11 +890,11 @@ test('clearDownstreamFields action - belowFile', function(assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello'
         });
 
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
@@ -905,7 +902,7 @@ test('clearDownstreamFields action - belowFile', function(assert) {
 
         ctrl.send('clearDownstreamFields', 'belowFile');
 
-        assert.equal(ctrl.get('node'), node);
+        assert.equal(ctrl.get('model'), preprint);
         assert.equal(ctrl.get('selectedFile'), 'Test file');
         assert.equal(ctrl.get('file'), 'file');
         assert.equal(ctrl.get('convertOrCopy'), null);
@@ -920,11 +917,11 @@ test('clearDownstreamFields action - belowNode', function(assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello'
         });
 
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
@@ -932,7 +929,7 @@ test('clearDownstreamFields action - belowNode', function(assert) {
 
         ctrl.send('clearDownstreamFields', 'belowNode');
 
-        assert.equal(ctrl.get('node'), node);
+        assert.equal(ctrl.get('model'), preprint);
         assert.equal(ctrl.get('selectedFile'), null);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('convertOrCopy'), null);
@@ -947,11 +944,11 @@ test('clearDownstreamFields action - allUpload', function(assert) {
     const ctrl = this.subject();
 
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello'
         });
 
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
@@ -959,7 +956,6 @@ test('clearDownstreamFields action - allUpload', function(assert) {
 
         ctrl.send('clearDownstreamFields', 'allUpload');
 
-        assert.equal(ctrl.get('node'), null);
         assert.equal(ctrl.get('selectedFile'), null);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('convertOrCopy'), null);
@@ -973,13 +969,10 @@ test('discardBasics', function(assert) {
     const store = this.store;
     const ctrl = this.subject();
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello',
             tags: ['first tag'],
-            description: 'The best abstract'
-        });
-
-        const preprint = store.createRecord('preprint', {
+            description: 'The best abstract',
             doi: '10.1234/test_doi',
             licenseRecord: {
                 'year': '2016',
@@ -989,7 +982,6 @@ test('discardBasics', function(assert) {
             originalPublicationDate: moment()
         });
 
-        ctrl.set('node', node);
         ctrl.set('model', preprint);
         ctrl.set('basicsTags', ['second Tag']);
         ctrl.set('basicsAbstract', 'Test abstract');
@@ -997,8 +989,8 @@ test('discardBasics', function(assert) {
         ctrl.set('basicsLicense', 'Test license');
         ctrl.set('basicsOriginalPublicationDate', moment().add(1, 'days'));
         ctrl.send('discardBasics');
-        assert.equal(ctrl.get('basicsTags')[0], node.get('tags')[0]);
-        assert.equal(ctrl.get('basicsAbstract'), node.get('description'));
+        assert.equal(ctrl.get('basicsTags')[0], preprint.get('tags')[0]);
+        assert.equal(ctrl.get('basicsAbstract'), preprint.get('description'));
         assert.equal(ctrl.get('basicsDOI'), preprint.get('doi'));
         assert.equal(ctrl.get('basicsOriginalPublicationDate'), preprint.get('originalPublicationDate'));
         // TODO promise hasn't resolved so this is incorrect.
@@ -1018,16 +1010,13 @@ skip('saveBasics', function(assert) {
     const store = this.store;
     const ctrl = this.subject();
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             title: 'hello',
             tags: ['tags'],
-            description: 'This is an abstract.'
-        });
-        const preprint = store.createRecord('preprint', {
+            description: 'This is an abstract.',
             primaryFile: 'Test file',
             'doi': '10.1234/test'
         });
-        ctrl.set('node', node);
         ctrl.set('model', preprint);
         ctrl.send('saveBasics');
         Ember.run.cancelTimers();

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -98,7 +98,7 @@ test('Initial properties', function (assert) {
         'file': null,
         'selectedFile': null,
         'contributors.length': 0,
-        'nodeTitle': null,
+        'title': null,
         'nodeLocked': false,
         'searchResults.length': 0,
         'savingPreprint': false,
@@ -336,9 +336,9 @@ test('titleChanged computed property', function(assert) {
             'title': 'Test title'
         });
         ctrl.set('model', preprint);
-        ctrl.set('nodeTitle', 'Test title');
+        ctrl.set('title', 'Test title');
         assert.equal(ctrl.get('titleChanged'), false);
-        ctrl.set('nodeTitle', 'Changed title');
+        ctrl.set('title', 'Changed title');
         assert.equal(ctrl.get('titleChanged'), true);
     });
 });
@@ -846,12 +846,12 @@ test('discardUploadChanges', function(assert) {
         ctrl.set('model', preprint);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('selectedFile'), null);
-        assert.equal(ctrl.get('nodeTitle'), null);
+        assert.equal(ctrl.get('title'), null);
         assert.equal(ctrl.get('titleValid'), null);
         ctrl.send('discardUploadChanges');
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('selectedFile.id'), file.id);
-        assert.equal(ctrl.get('nodeTitle'), 'hello');
+        assert.equal(ctrl.get('title'), 'hello');
         assert.equal(ctrl.get('titleValid'), true);
     });
 });
@@ -871,7 +871,7 @@ test('clearDownstreamFields action - belowConvertOrCopy', function(assert) {
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
-        ctrl.set('nodeTitle', 'Test title');
+        ctrl.set('title', 'Test title');
 
         ctrl.send('clearDownstreamFields', 'belowConvertOrCopy');
 
@@ -879,7 +879,7 @@ test('clearDownstreamFields action - belowConvertOrCopy', function(assert) {
         assert.equal(ctrl.get('selectedFile'), 'Test file');
         assert.equal(ctrl.get('file'), 'file');
         assert.equal(ctrl.get('convertOrCopy'), 'copy');
-        assert.equal(ctrl.get('nodeTitle'), null);
+        assert.equal(ctrl.get('title'), null);
     });
 });
 
@@ -898,7 +898,7 @@ test('clearDownstreamFields action - belowFile', function(assert) {
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
-        ctrl.set('nodeTitle', 'Test title');
+        ctrl.set('title', 'Test title');
 
         ctrl.send('clearDownstreamFields', 'belowFile');
 
@@ -906,7 +906,7 @@ test('clearDownstreamFields action - belowFile', function(assert) {
         assert.equal(ctrl.get('selectedFile'), 'Test file');
         assert.equal(ctrl.get('file'), 'file');
         assert.equal(ctrl.get('convertOrCopy'), null);
-        assert.equal(ctrl.get('nodeTitle'), null);
+        assert.equal(ctrl.get('title'), null);
     });
 });
 
@@ -925,7 +925,7 @@ test('clearDownstreamFields action - belowNode', function(assert) {
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
-        ctrl.set('nodeTitle', 'Test title');
+        ctrl.set('title', 'Test title');
 
         ctrl.send('clearDownstreamFields', 'belowNode');
 
@@ -933,7 +933,7 @@ test('clearDownstreamFields action - belowNode', function(assert) {
         assert.equal(ctrl.get('selectedFile'), null);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('convertOrCopy'), null);
-        assert.equal(ctrl.get('nodeTitle'), null);
+        assert.equal(ctrl.get('title'), null);
     });
 });
 
@@ -952,14 +952,14 @@ test('clearDownstreamFields action - allUpload', function(assert) {
         ctrl.set('selectedFile', 'Test file');
         ctrl.set('file', 'file');
         ctrl.set('convertOrCopy', 'copy');
-        ctrl.set('nodeTitle', 'Test title');
+        ctrl.set('title', 'Test title');
 
         ctrl.send('clearDownstreamFields', 'allUpload');
 
         assert.equal(ctrl.get('selectedFile'), null);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('convertOrCopy'), null);
-        assert.equal(ctrl.get('nodeTitle'), null);
+        assert.equal(ctrl.get('title'), null);
     });
 });
 

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -220,13 +220,13 @@ test('savedTitle computed property', function(assert) {
     const store = this.store;
     const ctrl = this.subject();
     Ember.run(() => {
-        const node = store.createRecord('node', {});
-        const nodeWithTitle = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {});
+        const preprintWithTitle = store.createRecord('preprint', {
             'title': 'Node title'
         });
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         assert.equal(ctrl.get('savedTitle'), false);
-        ctrl.set('node', nodeWithTitle);
+        ctrl.set('model', preprintWithTitle);
         assert.equal(ctrl.get('savedTitle'), true);
         Ember.run.cancelTimers();
     });
@@ -332,10 +332,10 @@ test('titleChanged computed property', function(assert) {
     this.inject.service('store');
     const store = this.store;
     Ember.run(() => {
-        const node = store.createRecord('node', {
+        const preprint = store.createRecord('preprint', {
             'title': 'Test title'
         });
-        ctrl.set('node', node);
+        ctrl.set('model', preprint);
         ctrl.set('nodeTitle', 'Test title');
         assert.equal(ctrl.get('titleChanged'), false);
         ctrl.set('nodeTitle', 'Changed title');
@@ -841,14 +841,12 @@ test('discardUploadChanges', function(assert) {
             'id': '12345'
         });
         const preprint = store.createRecord('preprint', {
-            'primaryFile': file
-        });
-        const node = store.createRecord('node', {
-            title: 'hello'
+            'primaryFile': file,
+            'title': 'hello',
         });
         const ctrl = this.subject();
+
         ctrl.set('model', preprint);
-        ctrl.set('node', node);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('selectedFile'), null);
         assert.equal(ctrl.get('nodeTitle'), null);


### PR DESCRIPTION
## Purpose

Grab more data from the preprint model instead of the node

## Summary of Changes
- Update the submit controller to save more data (title, tags, description) on the preprint model
- Update content controller and template to retrieve more data from preprint model
- Replace terminologies or variable names to reflect the changes.
- Update tests

## Side Effects / Testing Notes
The changes in this ticket affect preprint `submit` and`detail` pages.
- On the preprint submit page:
- At each section, make sure to fill out the info including the non-required fields: `tags, description, title` should not be blank to test this ticket.
- Make sure each section saves without errors (developer console or errors growlers)
- Visit the preprint you just created, and make sure there are no errors and
all the preprint info you entered is available, especially the `tags, title, description`.

## Ticket

[IN-97](https://openscience.atlassian.net/browse/IN-97)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
