### PR TITLE
[IN-67][Preprints] Remove redirect warning from submission page if no file selected

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -189,8 +189,9 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     hasFile: Ember.computed.or('file', 'selectedFile'),
 
     // True if fields have been changed
-    // If adding a preprint, hasDirtyFields will always be true to prevent leaving the page at all unless clicking submit
-    hasDirtyFields: Ember.computed.or('uploadChanged', 'basicsChanged', 'disciplineChanged', 'isAddingPreprint'),
+    hasDirtyFields: Ember.computed('hasFile', 'uploadChanged', 'basicsChanged', 'disciplineChanged', 'isAddingPreprint', function() {
+        return this.get('isAddingPreprint') && this.get('hasFile') || this.get('uploadChanged') || this.get('basicsChanged') || this.get('disciplineChanged');
+    }),
 
     isAddingPreprint: Ember.computed.not('editMode'),
 


### PR DESCRIPTION
## Purpose

If there isn't a file selected, the user shouldn't be warned about leaving the submission page.

## Summary of Changes

Add to `hasDirtyFields` to check if there is a file selected before showing the message to users

## Side Effects / Testing Notes

With these changes there should be four use cases to check for.  The warning message should pop up for user when:
- User is uploading a preprint and has selected their file
- User is editing a pre-existing preprint and has made changes

The message should not show up when:
- User goes to submission page and has not chosen a file to upload (or has clicked the back button on the submit block)
- User goes to edit page and hasn't made any changes to the file

## Ticket

https://openscience.atlassian.net/browse/IN-67

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(changes were already put in CHANGELOG with previous PR)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
