### PR TITLE
[IN-29][Preprints] Change 'Powered by Preprints' link to stay on current server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Get pagination info directly from meta in preprint-form-authors component
 - Check for `has_highlighted_subjects` flag to determine what wording should be used on index page
 - Use flexbox to show all provider logos in pretty rows
+- 'Powered by Preprints' link stay on current server
 
 ## [0.116.4] - 2018-01-29
 ### Changed

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Analytics from 'ember-osf/mixins/analytics';
+import config from 'ember-get-config';
 
 /**
  * @module ember-preprints
@@ -11,6 +12,7 @@ import Analytics from 'ember-osf/mixins/analytics';
  */
 export default Ember.Controller.extend(Analytics, {
     theme: Ember.inject.service(),
+    host: config.OSF.url,
     actions: {
         contactLink(href, category, action, label) {
             const metrics = Ember.get(this, 'metrics');

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -18,7 +18,7 @@
                             {{sanitize-html theme.provider.description "description"}}
                             <br>
                             <small>
-                                <a href="https://osf.io/preprints/" onbeforeclick={{action "click" "link" "Index - Powered By"}}>{{t "index.header.powered_by"}}</a>
+                                <a href="{{host}}preprints" onbeforeclick={{action "click" "link" "Index - Powered By"}}>{{t "index.header.powered_by"}}</a>
                             </small>
                         {{/if}}
                     </p>


### PR DESCRIPTION
## Purpose

To change the 'Powered by Preprints' link to stay on the current server.

## Summary of Changes

- Use `config.OSF.url` instead of a hard-coded link

## Side Effects / Testing Notes

This should only affect the 'Powered by Preprints' link on the index page of branded preprints.
The link should still point to `/preprints`, but the prefix should change according to whichever server you're currently on (i.e. `staging.osf.io/preprints`)

## Ticket

https://openscience.atlassian.net/browse/IN-29

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
