### PR TITLE
[IN-31][Preprints] Use facebookAppId if available for branded preprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Computed` to check if there has been user changes on the discipline field on the preprint submission/edit form
 - Translations for `Browse by featured subjects`, `Browse by subjects`, and `Browse by providers`
 - Add to `computed` to prevent redirect at any point on preprint submission
+- Check to use `facebookAppId` if branded providers have an app id
 
 ### Changed
 - Update to ember-osf 0.14.0

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -127,8 +127,9 @@ export default Ember.Controller.extend(Analytics, {
      * https://developers.facebook.com/docs/sharing/reference/share-dialog
      */
     facebookHref: Ember.computed('model', function() {
+        const facebookAppId = this.get('model.provider.facebookAppId') ? this.get('model.provider.facebookAppId') : config.FB_APP_ID;
         const queryParams = {
-            app_id: config.FB_APP_ID,
+            app_id: facebookAppId,
             display: 'popup',
             href: window.location.href,
             redirect_uri: window.location.href

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -84,6 +84,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 ]);
             })
             .then(([provider, node, license]) => {
+                const facebookAppId = provider.get('facebookAppId') ? provider.get('facebookAppId') : config.FB_APP_ID;
                 const title = node.get('title');
                 const description = node.get('description');
                 const mintDoi = extractDoiFromString(preprint.get('preprintDoiUrl'));
@@ -102,7 +103,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
 
                 // Open Graph Protocol
                 const openGraph = [
-                    ['fb:app_id', config.FB_APP_ID],
+                    ['fb:app_id', facebookAppId],
                     ['og:title', title],
                     ['og:image', imageUrl],
                     ['og:image:width', image.width.toString()],

--- a/tests/unit/controllers/content/index-test.js
+++ b/tests/unit/controllers/content/index-test.js
@@ -84,16 +84,58 @@ test('twitterHref computed property', function (assert) {
     });
 });
 
-test('facebookHref computed property', function (assert) {
+test('facebookHref computed property - has facebookAppId', function (assert) {
+    this.inject.service('store');
+
+    const store = this.store;
+    const ctrl = this.subject();
+    const facebookAppId = 112233445566;
+
+    Ember.run(() => {
+        const provider = store.createRecord('preprint-provider', {
+            facebookAppId: facebookAppId,
+        });
+
+        const model = store.createRecord('preprint', {
+            provider,
+        });
+
+        ctrl.setProperties({ model });
+
+        const location = encodeURIComponent(window.location.href);
+
+        assert.strictEqual(
+            ctrl.get('facebookHref'),
+            `https://www.facebook.com/dialog/share?app_id=${facebookAppId.toString()}&display=popup&href=${location}&redirect_uri=${location}`
+        );
+    });
+});
+
+test('facebookHref computed property - does not have facebookAppId', function(assert) {
+    this.inject.service('store');
+
+    const store = this.store;
     const ctrl = this.subject();
 
-    const {FB_APP_ID} = config;
-    const location = encodeURIComponent(window.location.href);
+    Ember.run(() => {
+        const provider = store.createRecord('preprint-provider', {
+            facebookAppId: '',
+        });
 
-    assert.strictEqual(
-        ctrl.get('facebookHref'),
-        `https://www.facebook.com/dialog/share?app_id=${FB_APP_ID}&display=popup&href=${location}&redirect_uri=${location}`
-    );
+        const model = store.createRecord('preprint', {
+            provider,
+        });
+
+        ctrl.setProperties({ model });
+
+        const { FB_APP_ID } = config;
+        const location = encodeURIComponent(window.location.href);
+
+        assert.strictEqual(
+            ctrl.get('facebookHref'),
+            `https://www.facebook.com/dialog/share?app_id=${FB_APP_ID}&display=popup&href=${location}&redirect_uri=${location}`
+        );
+    });
 });
 
 test('linkedinHref computed property', function (assert) {


### PR DESCRIPTION
## Purpose

Use the new `facebookAppId` property as the Facebook app ID for branded providers if it's available.

## Summary of Changes

- Use branded provider's Facebook app ID in the meta tags and in the share button

ID specified in the admin app
![screen shot 2018-02-12 at 3 41 40 pm](https://user-images.githubusercontent.com/19379783/36119520-27085cda-100e-11e8-944a-6442252abcd8.png)

ID shows up in the URL when going to share the link
![screen shot 2018-02-12 at 3 38 59 pm](https://user-images.githubusercontent.com/19379783/36119541-321ce8e8-100e-11e8-9948-1e554ae5d77d.png)

ID shows up in the meta tags
![screen shot 2018-02-12 at 3 39 21 pm](https://user-images.githubusercontent.com/19379783/36119561-40c03b20-100e-11e8-8011-b21c87f6cceb.png)


## Side Effects / Testing Notes

This should use the `facebookAppId` for branded providers if they have an app ID specified in the admin app.  It should change the Facebook app ID in the meta tags and when sharing a preprint.

## Ticket

https://openscience.atlassian.net/browse/IN-31

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [x] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
