### PR TITLE
[IN-175][Preprints] Remove warning modal on submit page if there haven't been changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Warning modal on submit page to only show after changes have been made
 
 ## [0.117.2] - 2018-02-09
 ### Changed

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -190,7 +190,10 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
 
     // True if fields have been changed
     hasDirtyFields: Ember.computed('hasFile', 'uploadChanged', 'basicsChanged', 'disciplineChanged', 'isAddingPreprint', function() {
-        return this.get('isAddingPreprint') && this.get('hasFile') || this.get('uploadChanged') || this.get('basicsChanged') || this.get('disciplineChanged');
+        if (this.get('isAddingPreprint') && !this.get('hasFile') && !this.get('node')) {
+            return false;
+        }
+        return this.get('uploadChanged') || this.get('basicsChanged') || this.get('disciplineChanged');
     }),
 
     isAddingPreprint: Ember.computed.not('editMode'),


### PR DESCRIPTION
## Purpose

If the user doesn't make any changes on the submit page, the warning modal shows up anyway when they try to leave.  It should only show up if the user has added a file/made changes.

## Summary of Changes

- Separated the check for if there is a file uploaded && you're adding a file
- Added onto that check for whether or not user selected a node instead of uploaded a file

## Side Effects / Testing Notes

There are a few cases to check:

- If the user goes to submission page: **should not display warning**
- If the user uploads a file: **should display warning**
- If the user selects a node: **should display warning**

## Ticket

https://openscience.atlassian.net/browse/IN-175

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
