### PR TITLE
[IN-169][Preprints] Make the preprint provider logos smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Warning modal on submit page to only show after changes have been made
+- Improve the appearance of the preprint provider logos on the OSFPreprints landing page
 
 ## [0.117.2] - 2018-02-09
 ### Changed

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1460,11 +1460,11 @@ nav.branded-navbar {
         display: block;
         flex: 1 0 auto;
         box-sizing: border-box;
-        height: 120px;
+        height: 75px;
         background-size: contain;
         background-repeat: no-repeat;
         background-position: center;
-        min-width: 200px;
+        min-width: 150px;
         margin: 15px;
     }
 }


### PR DESCRIPTION
## Purpose
Make the preprint provider logos smaller on the OSFPreprints landing page.


## Summary of Changes
Reduced the height and min-width of the preprint provider logos on the OSFPreprints landing page.

**Before:**
![current-provider-layout-120px_200px](https://user-images.githubusercontent.com/7131985/36278718-a5ce4ea2-1262-11e8-87ea-7c7893db9773.png)

**After:**
![75px_150px](https://user-images.githubusercontent.com/7131985/36278729-ae44905a-1262-11e8-90d8-fe9f64678559.png)


## Side Effects / Testing Notes
Check the logos at multiple screen widths.


## Ticket

https://openscience.atlassian.net/browse/IN-169

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
