### PR TITLE
[IN-183][Fix] Increase page size to 150 for taxonomies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Increase taxonomies page size from 100 to 150
 
 ## [0.117.3] - 2018-02-20
 ### Changed

--- a/app/components/subject-picker/component.js
+++ b/app/components/subject-picker/component.js
@@ -57,10 +57,10 @@ export default Ember.Component.extend(Analytics, {
             .then(provider => provider
                 .queryHasMany('taxonomies', {
                     filter: {
-                        parents
+                        parents,
                     },
                     page: {
-                        size: 100
+                        size: 150,  // Law category has 117 (Jan 2018)
                     }
                 })
             )


### PR DESCRIPTION
## Purpose
Show all of the available subjects on the preprint submission page.


## Summary of Changes
Change page size from 100 --> 150.


## Side Effects / Testing Notes
Impacts anyone who allows all of the "Law" subjects (lawarxiv, frenxiv, osf, arabixiv, thesiscommons, inarxiv).

Easiest way to check that the page size has increased is to click on the law category while the console is open and look at the request on the Network tab (can filter to XHR).

![screen shot 2018-02-21 at 2 13 58 pm](https://user-images.githubusercontent.com/7131985/36500289-eab8be86-1711-11e8-9f56-c116d60a27dd.png)

## Ticket

https://openscience.atlassian.net/browse/IN-183

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
