### PR TITLE
[IN-190][Preprints] Improve spacing of preprint logo display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Pull more preprint data (`title`, `description`, `tags`, etc.) from the preprint model instead of the node model.
 - Use newly added `name` field for preprint detail page contributors
 - Modified `preprint-form-project-select` component to use `lazy-options` for lazy loading user nodes.
+- Restricted width and centered preprint provider logos on index page
 
 ### Fixed
 - Skipped tests in `convert-or-copy-project-test` and `supplementary-file-browser` to run properly

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1464,6 +1464,7 @@ nav.branded-navbar {
     padding: 20px;
     margin-left: auto;
     margin-right: auto;
+    justify-content: center;
 
     .provider-logo-item {
         display: block;
@@ -1474,6 +1475,7 @@ nav.branded-navbar {
         background-repeat: no-repeat;
         background-position: center;
         min-width: 150px;
+        max-width: 150px;
         margin: 15px;
     }
 }


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Improve spacing of preprint logo display

## Summary of Changes

* restrict provider logo width
* center justify content within provider logos container

## Side Effects / Testing Notes

Check on all browsers.

## Ticket

https://openscience.atlassian.net/browse/IN-190

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
