### PR TITLE
[IN-235][Preprints] Update to use latest osf-style with navbar changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `osf-style` to use the latest version with navbar changes
 
 ## [0.118.3] - 2018-03-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2018-03-12T20:00:53Z",
-    "@centerforopenscience/osf-style": "1.5.1",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2018-03-12T20:00:53Z",
-    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#develop",
+    "@centerforopenscience/osf-style": "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
     moment-timezone "^0.5.13"
     toastr "^2.1.2"
 
-"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8":
   version "1.6.0"
   resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,9 +42,9 @@
     moment-timezone "^0.5.13"
     toastr "^2.1.2"
 
-"@centerforopenscience/osf-style@1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.5.1.tgz#3ea1a0807c02d06d32bf346620a538613880bc59"
+"@centerforopenscience/osf-style@https://github.com/CenterForOpenScience/osf-style#develop":
+  version "1.6.0"
+  resolved "https://github.com/CenterForOpenScience/osf-style#b09451d759c8544d2fab4bd7dbd5ca8b6dc242b8"
 
 JSONStream@^1.0.3:
   version "1.3.1"


### PR DESCRIPTION
## Purpose

New navbar changes have been merged into `osf-style`.  We should update to use the newest version of the navbar.

## Summary of Changes

- Update `osf-style` dependency to point at the latest version

## Side Effects / Testing Notes

Should use the newest navbar with flexbox

## Ticket

https://openscience.atlassian.net/browse/IN-95

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
