### PR TITLE
[IN-76] [Preprints] Clear previous basicsLicense.licenseType when changing providers

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1195,6 +1195,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             this.set('currentProvider', this.get('selectedProvider'));
             this.get('currentProvider').queryHasMany('licensesAcceptable', {'page[size]': 20}).then(licenses => {
                 this.set('availableLicenses', licenses);
+                this.set('basicsLicense.licenseType', this.get('availableLicenses.firstObject'));
             });
             this.set('providerChanged', false);
             this.set('providerSaved', true);


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix a bug where default license was not not updated when changing providers.

## Summary of Changes

Clear the default license when saving the provider so that it is forced to be reset to the first license in the updated list of available licenses.

## Side Effects / Testing Notes

Make sure saving basics works for a provider that does not include the default OSF license.

## Ticket

https://openscience.atlassian.net/browse/IN-76

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] ~~changes described in `CHANGELOG.md`~~ *(this fixes a bug in unreleased code)*

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
