### PR TITLE
[IN-97][Preprints] Fix validation icons

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -192,17 +192,18 @@ export default Ember.Component.extend(Analytics, {
             if (this.get('nodeLocked')) { // Edit mode
                 this.set('uploadInProgress', true);
             }
-            let node = this.get('node');
-            this.set('basicsAbstract', this.get('node.description') || null);
-            let currentTitle = node.get('title');
-            if (node.get('title') !== this.get('title')) {
-                node.set('title', this.get('title'));
-                node.save()
+
+            let model = this.get('model');
+            this.set('basicsAbstract', this.get('model.description') || null);
+            let currentTitle = model.get('title');
+            if (model.get('title') !== this.get('title')) {
+                model.set('title', this.get('title'));
+                model.save()
                 .then(() => {
                     this.send('upload');
                 })
                 .catch(() => {
-                    node.set('title', currentTitle);
+                    model.set('title', currentTitle);
                     this.set('uploadInProgress', false);
                     this.get('toast').error(this.get('i18n').t('components.file-uploader.could_not_update_title'));
                 });

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -431,7 +431,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     // Compares the model's and current subjectLists's array of arrays of discipline ids
     // to determine if there has been a change.
     disciplineChanged: Ember.computed('model.subjects.@each.subject', 'subjectsList.@each.subject', 'disciplineModifiedToggle', function () {
-        return JSON.stringify(this.get('model.subjects')) !== JSON.stringify(this.get('subjectsList'));
+        return JSON.stringify(subjectIdMap(this.get('model.subjects'))) !== JSON.stringify(subjectIdMap(this.get('subjectsList')));
     }),
 
     // Returns all contributors of node that will be container for preprint.  Makes sequential requests to API until all pages of contributors have been loaded
@@ -660,7 +660,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             const currentTitle = model.get('title');
             const title = this.get('title');
 
-            this.set('basicsAbstract', this.get('node.description') || null);
+            this.set('basicsAbstract', this.get('model.description') || null);
 
             return Promise.resolve()
                 .then(() => {

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -51,7 +51,7 @@ export default Ember.Mixin.create({
         controller.set('filePickerState', 'existing'); // In edit mode, dealing with existing project
         controller.set('existingState', 'new'); // In edit mode, only option to change file is to upload a NEW file
         controller.set('node', node);
-        controller.set('title', node.get('title'));
+        controller.set('title', model.get('title'));
         controller.set('nodeLocked', true);
         controller.set('titleValid', true);
         model.get('primaryFile').then((file) => {

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -107,6 +107,7 @@
                     hasFile=hasFile
                     file=file
                     contributors=contributors
+                    model=model
                     node=node
                     selectedNode=selectedNode
                     parentNode=parentNode

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -109,6 +109,7 @@
                                               hasFile=hasFile
                                               file=file
                                               node=node
+                                              model=model
                                               selectedNode=node
                                               contributors=contributors
                                               fileSelect=true


### PR DESCRIPTION
## Purpose

Fix issue where validation indicators on `upload` and `discipline` sections
stay red after saving that section.

## Summary of Changes

- Update save action to use preprint instead of node model.
- Fix `disciplineChanged` computed property by using `subjectIdMap`.

## Side Effects / Testing Notes

Follow up PR to https://github.com/CenterForOpenScience/ember-osf-preprints/pull/526
On the preprint submit page, make sure the icons turn green from red when you save the section
both in upload or edit mode. 

## Ticket

[IN-97](https://openscience.atlassian.net/browse/IN-97)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
