### PR TITLE
[IN-97][Preprints] Keep node updates on preprint changes 

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -194,16 +194,19 @@ export default Ember.Component.extend(Analytics, {
             }
 
             let model = this.get('model');
+            let node = this.get('node');
             this.set('basicsAbstract', this.get('model.description') || null);
-            let currentTitle = model.get('title');
-            if (model.get('title') !== this.get('title')) {
+            let currentNodeTitle = node.get('title');
+
+            if (currentNodeTitle !== this.get('title')) {
                 model.set('title', this.get('title'));
-                model.save()
+                node.set('title', this.get('title'));
+                node.save()
                 .then(() => {
                     this.send('upload');
                 })
                 .catch(() => {
-                    model.set('title', currentTitle);
+                    node.set('title', currentNodeTitle);
                     this.set('uploadInProgress', false);
                     this.get('toast').error(this.get('i18n').t('components.file-uploader.could_not_update_title'));
                 });

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -657,19 +657,24 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                 });
 
             const model = this.get('model');
-            const currentTitle = model.get('title');
+            const node = this.get('node');
+            const currentNodeTitle = node.get('title');
             const title = this.get('title');
 
             this.set('basicsAbstract', this.get('model.description') || null);
 
             return Promise.resolve()
                 .then(() => {
-                    if (currentTitle !== title) {
-                        model.set('title', title);
+                    if (currentNodeTitle === title) {
+                        return;
                     }
+                    model.set('title', title);
+                    node.set('title', title);
+                    return node.save();
                 })
                 .then(() => this.send(this.get('abandonedPreprint') ? 'resumeAbandonedPreprint' : 'startPreprint'))
                 .catch(() => {
+                    node.set('title', currentNodeTitle);
                     this.get('toast').error(
                         this.get('i18n').t('submit.could_not_update_title')
                     );


### PR DESCRIPTION
## Purpose

Not updating the existing node on preprint changes seems to cause lots
of issues.

## Summary of Changes

Modify `uploadFileToExistingNode` to save changes both on the `preprint` and `node` models.

## Side Effects / Testing Notes

## Ticket

[IN-97](https://openscience.atlassian.net/browse/IN-97)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
