### PR TITLE
[IN-205][Preprints] Use url from config for search request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Use `config.OSF.url` for base of v1 contributor search to prevent branded domains from breaking
 
 ## [0.118.1] - 2018-03-06
 ## Fixed

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -9,10 +9,9 @@ import NodeActionsMixin from 'ember-osf/mixins/node-actions';
 import TaggableMixin from 'ember-osf/mixins/taggable-mixin';
 
 import loadAll from 'ember-osf/utils/load-relationship';
-
 import fixSpecialChar from 'ember-osf/utils/fix-special-char';
-
 import extractDoiFromString from 'ember-osf/utils/extract-doi-from-string';
+import pathJoin from 'ember-osf/utils/path-join';
 
 // Enum of available upload states > New project or existing project?
 export const State = Object.freeze(Ember.Object.create({
@@ -1039,7 +1038,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     action: 'click',
                     label: `${this.get('editMode') ? 'Edit' : 'Submit'} - Search for Authors`
                 });
-            const url = `/api/v1/user/search/?query=${query}&page=${page - 1}&size=10`;
+            const url = pathJoin(config.OSF.url, `api/v1/user/search/?query=${query}&page=${page - 1}&size=10`);
             let metaPages;
             return Ember.$.ajax({
                 type: 'GET',


### PR DESCRIPTION
## Purpose
Branded domains can't search for contributors to add.

Introduced by the 0.118.0 release: https://github.com/CenterForOpenScience/ember-osf-preprints/commit/21847af63c170d8f2bf3e1ca73032d8e5cad7d46

## Summary of Changes
Set the base url of the request to `config.OSF.url` instead of using a relative url.


## Side Effects / Testing Notes
Contributor search should work for both branded and unbranded providers.


## Ticket

https://openscience.atlassian.net/browse/IN-205

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
