### PR TITLE
[IN-203][Preprints] Upgrade moment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- ember-cli-moment-shim version to `^3.5.3` due to security issues found in `moment` versions before `2.19.3`
 
 ## [0.118.3] - 2018-03-12
 ### Added

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-cli-inject-live-reload": "1.4.0",
     "ember-cli-inline-content": "0.4.0",
     "ember-cli-meta-tags": "3.0.1",
-    "ember-cli-moment-shim": "3.3.1",
+    "ember-cli-moment-shim": "^3.5.3",
     "ember-cli-postcss": "3.0.1",
     "ember-cli-qunit": "3.0.0",
     "ember-cli-release": "0.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1573,7 +1573,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0, broccoli-stew@^1.4.2, broccoli-stew@^1.5.0:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.2, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2983,21 +2983,6 @@ ember-cli-meta-tags@3.0.1:
     ember-cli-head "0.0.6"
     ember-cli-htmlbars "^1.0.1"
 
-ember-cli-moment-shim@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.3.1.tgz#5868095247ca3df6cf24ee413889423342e39549"
-  dependencies:
-    broccoli-funnel "^1.1.0"
-    broccoli-merge-trees "^2.0.0"
-    broccoli-stew "^1.4.0"
-    chalk "^1.1.3"
-    ember-cli-babel "^5.1.7"
-    ember-cli-import-polyfill "^0.2.0"
-    exists-sync "^0.0.4"
-    lodash.defaults "^4.2.0"
-    moment "^2.18.1"
-    moment-timezone "~0.5.11"
-
 ember-cli-moment-shim@^3.3.1:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.5.3.tgz#ab42a67b679a9b3264663e55a65299e039002199"
@@ -3008,6 +2993,22 @@ ember-cli-moment-shim@^3.3.1:
     broccoli-stew "^1.5.0"
     chalk "^1.1.3"
     ember-cli-babel "^6.8.2"
+    ember-cli-import-polyfill "^0.2.0"
+    exists-sync "^0.0.4"
+    lodash.defaults "^4.2.0"
+    moment "^2.19.3"
+    moment-timezone "^0.5.13"
+
+ember-cli-moment-shim@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.6.0.tgz#a6ce858e99b285eb9c539c8cebb698435f8d043a"
+  dependencies:
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-source "^1.1.0"
+    broccoli-stew "^1.5.0"
+    chalk "^1.1.3"
+    ember-cli-babel "^6.6.0"
     ember-cli-import-polyfill "^0.2.0"
     exists-sync "^0.0.4"
     lodash.defaults "^4.2.0"
@@ -6274,13 +6275,13 @@ moment-timezone@^0.3.0:
   dependencies:
     moment ">= 2.6.0"
 
-moment-timezone@^0.5.13, moment-timezone@~0.5.11:
+moment-timezone@^0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.13.tgz#99ce5c7d827262eb0f1f702044177f60745d7b90"
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.6.0", "moment@>= 2.9.0", moment@^2.18.1:
+"moment@>= 2.6.0", "moment@>= 2.9.0":
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 


### PR DESCRIPTION
## Purpose

Fix security vulnerability: [CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214)

## Summary of Changes

`yarn upgrade "ember-cli-moment-shim@^3.5.3"` which also upgrades moment to ^2.19.3

## Side Effects / Testing Notes

N/A

## Ticket

[IN-203](https://openscience.atlassian.net/browse/IN-203)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`