### PR TITLE
[IN-237][Preprints] Open upload section for branded providers

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -40,7 +40,17 @@
                     {{/unless}}
 
                     {{#with _names.[1] as |name|}}
-                        {{#preprint-form-section id='preprint-form-upload' editMode=editMode class="preprint-form-block" name=name allowOpen=(or providerSaved editMode) denyOpenMessage=(t 'submit.please_select_server') errorAction=(action 'error') as |hasOpened|}}
+                        {{#preprint-form-section
+                            id='preprint-form-upload'
+                            editMode=editMode
+                            class="preprint-form-block"
+                            name=name
+                            allowOpen=(or providerSaved editMode)
+                            open=(and theme.isProvider (not editMode))
+                            denyOpenMessage=(t 'submit.please_select_server')
+                            errorAction=(action 'error')
+                            as |hasOpened|
+                        }}
                             {{preprint-form-header editMode=editMode uploadSaveState=uploadSaveState showValidationIndicator=true name=name preprintNode=node preprintFile=model.primaryFile isValidationActive=(upload-validation-active editMode nodeLocked hasOpened) preprintTitle=node.title valid=(not uploadChanged)}}
                             {{#preprint-form-body}}
                                 {{#liquid-bind filePickerState class='translate' as |currentState|}}


### PR DESCRIPTION
## Purpose
Fix issue where upload section isn't open for branded submission pages.

## Summary of Changes
* Add `open=(and theme.isProvider (not editMode))` to upload section.
* Break the line into multiple so it's easier to read

![screen shot 2018-04-04 at 5 05 36 pm](https://user-images.githubusercontent.com/7131985/38334923-bdb6026a-382a-11e8-93e2-62d812ebb633.png)

## Side Effects / Testing Notes
For branded providers the upload section on the submit form should be automatically open.

For the OSF's submit form the providers section should be automatically open and the upload section should open after a provider has been selected.

## Ticket

https://openscience.atlassian.net/browse/IN-237

# Reviewer Checklist

- [x] meets requirements
- [x] easy to understand
- [x] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
