### PR TITLE
[IN-22][Preprints] Fix author list with long names and small screens

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -790,7 +790,7 @@ hr {
         }
         &.cp-is-open {
             opacity: 1;
-            padding: 15px;
+            padding: 5px;
         }
     }
     // THESE STYLES ARE INTERFERING WITH MY STYLES.

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1190,6 +1190,10 @@ label.title-label {
     cursor: default;
 }
 
+.panel-body {
+    padding: 15px 0 15px 0;
+}
+
 // Narrow views for submit
 @media (max-width: 768px) {
     #preprint-form-upload .btn-big {

--- a/app/styles/authors.scss
+++ b/app/styles/authors.scss
@@ -31,11 +31,17 @@
     padding-top: 8px;
     margin-top: 0;
     margin-bottom: 0;
-    width: 60px;
+    max-width: 120px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     display: inline-block;
+}
+// More room for name when single column
+@media (max-width: 992px) {
+    .vert-align-contributor-name {
+        max-width: 300px;
+    }
 }
 
 .bib-padding {

--- a/app/styles/authors.scss
+++ b/app/styles/authors.scss
@@ -1,19 +1,19 @@
 .vert-align-disabled-permissions {
     padding-top: 6px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .vert-align-enabled-permissions {
     padding-top: 2px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .drag-drop-contrib {
     padding-top: 4px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
     color: gray;
 }
 
@@ -23,14 +23,19 @@
 }
 .vert-align {
     padding-top: 4px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .vert-align-contributor-name {
     padding-top: 8px;
-    margin-top: 0px;
-    margin-bottom: 0px;
+    margin-top: 0;
+    margin-bottom: 0;
+    width: 60px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: inline-block;
 }
 
 .bib-padding {
@@ -125,7 +130,7 @@ span.sortable-bars:hover {
   background:none;
   border:none;
   font-size:1em;
-  padding:0px;
+  padding:0;
 }
 
 @keyframes greenHighlight {
@@ -166,6 +171,11 @@ span.sortable-bars:hover {
 .errorHighlight {
     animation: redHighlight 2s;
 }
+
+.table > tbody > tr > td {
+    padding: 5px;
+}
+
 @media (max-width: 768px) { // Contributors section, XS screen
     .current-authors {
         table, td, tr {
@@ -205,19 +215,19 @@ span.sortable-bars:hover {
         }
 
         .vert-align-disabled-permissions {
-            padding-top: 0px;
+            padding-top: 0;
         }
         .vert-align-enabled-permissions {
-            padding-top: 0px;
+            padding-top: 0;
         }
         .drag-drop-contrib {
-            padding-top: 0px;
+            padding-top: 0;
         }
         .vert-align {
-            padding-top: 0px;
+            padding-top: 0;
         }
         .vert-align-contributor-name {
-            padding-top: 0px;
+            padding-top: 0;
         }
         .contributor-row {
             border-top: 1px solid #EEE !important;

--- a/app/templates/components/preprint-form-authors.hbs
+++ b/app/templates/components/preprint-form-authors.hbs
@@ -115,7 +115,7 @@
                 {{#sortable-group tagName="tbody" onChange="reorderItems" as |group|}}
                     {{#each contributors as |contrib|}}
                         {{#sortable-item tagName="tr" model=contrib class="contributor-row" group=group spacing=1 handle=".handle" id=contrib.id}}
-                            <td class="text-nowrap author-cols">
+                            <td class="text-nowrap author-cols" title={{if contrib.unregisteredContributor contrib.unregisteredContributor contrib.users.fullName}}>
                                 <div class="form-group drag-drop-contrib">
                                     <span class="fa fa-bars sortable-bars handle small"></span>
                                     <img class="m-l-xs" src={{contrib.users.profileImage}} height=30 width=30>
@@ -135,7 +135,7 @@
                                     </span>
                                 </div>
                             </td>
-                            <td>
+                            <td title={{if contrib.unregisteredContributor contrib.unregisteredContributor contrib.users.fullName}}>
                                 <div class="vert-align-contributor-name hidden-xs">
                                     {{#if contrib.unregisteredContributor}}
                                         {{contrib.unregisteredContributor}}

--- a/tests/unit/components/preprint-form-authors-test.js
+++ b/tests/unit/components/preprint-form-authors-test.js
@@ -1,0 +1,78 @@
+import Ember from 'ember';
+import { moduleForComponent } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+
+
+moduleForComponent('preprint-form-authors', 'Unit | Component | preprint form authors', {
+    // Specify the other units that are required for this test
+    // needs: ['component:foo', 'helper:bar'],
+    unit: true,
+    needs: [
+        'model:node',
+        'model:user',
+        'model:preprint',
+        'model:preprint-provider',
+        'model:institution',
+        'model:comment',
+        'model:contributor',
+        'model:citation',
+        'model:file-provider',
+        'model:registration',
+        'model:draft-registration',
+        'model:log',
+        'model:taxonomy',
+        'model:license',
+        'model:wiki',
+        'service:i18n',
+        'service:theme',
+        'service:session',
+        'service:head-tags',
+    ],
+});
+
+
+test('currentContributorIds computed property', function(assert) {
+    const component = this.subject();
+    this.inject.service('store');
+
+    Ember.run(() => {
+        const contributor = this.store.createRecord('contributor', {userId: 'quedd'});
+
+        const node = this.store.createRecord('node', {
+            title: 'test title',
+            description: 'test description',
+            contributors: [contributor],
+        });
+
+        component.set('contributors', node.get('contributors'));
+        assert.deepEqual(component.get('currentContributorIds'), ['quedd']);
+    });
+});
+
+test('sendEmail computed property', function(assert) {
+    const component = this.subject();
+    component.set('editMode', true);
+    assert.strictEqual(component.get('sendEmail'), 'preprint');
+    component.set('editMode', false);
+    assert.strictEqual(component.get('sendEmail'), false);
+});
+
+test('numParentContributors computed property', function(assert) {
+    const component = this.subject();
+    this.inject.service('store');
+
+    Ember.run(() => {
+        const contributor1 = this.store.createRecord('contributor', {userId: 'quedd'});
+        const contributor2 = this.store.createRecord('contributor', {userId: 'rsffe'});
+
+
+        const node = this.store.createRecord('node', {
+            title: 'test title',
+            description: 'test description',
+            contributors: [contributor1, contributor2],
+        });
+
+        component.set('parentNode', node);
+        assert.deepEqual(component.get('numParentContributors'), 2);
+    });
+});


### PR DESCRIPTION
## Purpose
Fix Author list with long names and smaller screens. The problem shows with Long name strings or small window sizing.

## Summary of Changes

- Update styling for author table (use ellipses and tooltip) 


## Side Effects / Testing Notes
1. Confirm various sizes render the name or cut it off if too long.
2. Confirm that no buttons are lost with names that are too long, short or various window widths (this occurred while I was right-sizing the max-width)

After Alex's modification, slightly more text visible for name col:
<img width="568" alt="screen shot 2018-04-04 at 5 29 25 pm" src="https://user-images.githubusercontent.com/1322421/38336071-8d57da0e-382e-11e8-8abc-89bb8ba8ba4e.png">
<img width="731" alt="screen shot 2018-04-04 at 5 29 33 pm" src="https://user-images.githubusercontent.com/1322421/38336078-91a2abc0-382e-11e8-9423-d83c5e2911ff.png">



## Ticket

https://openscience.atlassian.net/browse/IN-22

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
