### PR TITLE
[WIP][IN-170] Allow toggling hypothesis

### DIFF
--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -23,12 +23,15 @@ import fileDownloadPath from '../utils/file-download-path';
  * @class supplementary-file-browser
  */
 export default Ember.Component.extend(Analytics, {
+    theme: Ember.inject.service(),
+
     elementId: 'preprint-file-view',
     endIndex: 6,
     startIndex: 0,
 
     scrollAnim: '',
     selectedFile: null,
+    allowCommenting: false,
 
     hasAdditionalFiles: function() {
         return this.get('files.length') > 1;
@@ -111,8 +114,14 @@ export default Ember.Component.extend(Analytics, {
     init() {
         this._super(...arguments);
         this.__files();
-
     },
+
+    didReceiveAttrs() {
+        this.get('theme.provider').then( provider => {
+            this.set('allowCommenting', provider.get('allowCommenting'));
+        });
+    },
+
     actions: {
         next(direction) {
             Ember.get(this, 'metrics')

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -1,5 +1,8 @@
-{{#file-renderer download=selectedFile.links.download
-    width="99%" height="700"}}
+{{#file-renderer
+    download=selectedFile.links.download
+    allowCommenting=allowCommenting
+    width="99%"
+    height="700"}}
 {{/file-renderer}}
 
 <div class="row">

--- a/tests/integration/components/supplementary-file-browser-test.js
+++ b/tests/integration/components/supplementary-file-browser-test.js
@@ -1,6 +1,15 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 
+const themeStub = Ember.Service.extend({
+    isProvider: true,
+    provider: Ember.RSVP.resolve(Ember.Object.create({
+        name: 'OSF',
+        allowCommenting: false,
+        additionalProviders: ['Other Provider'],
+    })),
+});
+
 moduleForComponent('supplementary-file-browser', 'Integration | Component | supplementary file browser', {
     integration: true,
     beforeEach: function() {
@@ -35,6 +44,9 @@ moduleForComponent('supplementary-file-browser', 'Integration | Component | supp
             id: 890
         });
         let dualTrackNonContributors = () => {};
+
+        this.register('service:theme', themeStub);
+        this.inject.service('theme');
 
         this.set('preprint', preprint);
         this.set('node', node);


### PR DESCRIPTION
_This should go to it's own release branch not develop_

## Purpose
Allow toggling hypothesis based on preprint provider setting.

## Summary of Changes
* Pass allowCommenting to file renderer

## Depends on
https://github.com/CenterForOpenScience/ember-osf/pull/377
https://github.com/CenterForOpenScience/osf.io/pull/8279

MFR changes are on staging.

## Side Effects / Testing Notes
The Hypothesis controls should show up on pdfs/docx files if the provider has `allow_commenting` set to true. `allow_commenting` can be changed from the OSF admin app on the preprint provider detail view.


## Ticket
https://openscience.atlassian.net/browse/IN-170

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
