### PR TITLE
[WIP][IN-271][Preprints] Resave preprint file relationship on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.118.3] - 2018-03-12
 ### Added
 - Event Tracking to `Select a Preprint Provider` on preprint upload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Event Tracking to `Select a Preprint Provider` on preprint upload
+
+### Changed
 - Restricted width and centered preprint provider logos on index page
 
 ## [0.118.2] - 2018-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.118.1] - 2018-03-06
 ## Fixed
 - Provider assets on production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Restricted width and centered preprint provider logos on index page
 
 ## [0.118.2] - 2018-03-08
 ### Removed
 - Ability to search by social fields (reverted)
 
 ## [0.118.1] - 2018-03-06
-## Fixed
+### Fixed
 - Provider assets on production
 
 ## [0.118.0] - 2018-03-06

--- a/app/components/preprint-form-header.js
+++ b/app/components/preprint-form-header.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import CpPanelToggleComponent from 'ember-collapsible-panel/components/cp-panel-toggle';
-import config from 'ember-get-config';
 /**
  * @module ember-preprints
  * @submodule components
@@ -28,7 +27,6 @@ export default CpPanelToggleComponent.extend({
     showValidationIndicator: true,
     valid: null,
     isValidationActive: false,
-    providerAssetsURL: config.providerAssetsURL,
 
     // Calculated properties
     invalid: Ember.computed('valid', 'isValidationActive', function() {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -11,7 +11,6 @@ import TaggableMixin from 'ember-osf/mixins/taggable-mixin';
 import loadAll from 'ember-osf/utils/load-relationship';
 import fixSpecialChar from 'ember-osf/utils/fix-special-char';
 import extractDoiFromString from 'ember-osf/utils/extract-doi-from-string';
-import pathJoin from 'ember-osf/utils/path-join';
 
 // Enum of available upload states > New project or existing project?
 export const State = Object.freeze(Ember.Object.create({

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1103,39 +1103,47 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             this.toggleProperty('shareButtonDisabled');
             model.set('provider', this.get('currentProvider'));
 
-            let submitAction = null;
-            if (this.get('moderationType')) {
-                submitAction = this.get('store').createRecord('review-action', {
-                   actionTrigger: 'submit',
-                   target: this.get('model')
-                });
-            } else {
+            const isModerated = this.get('moderationType');
+            if (!isModerated) {
                 model.set('isPublished', true);
             }
             node.set('public', true);
 
-            let save_changes = null;
-            if (submitAction) {
-                save_changes = model.save().then(() => node.save()).then(() => submitAction.save());
-            } else {
-                save_changes = model.save().then(() => node.save());
-            }
-
-            return save_changes
+            return model.save()
+                .then(() => node.save())
                 .then(() => {
-                        this.set('preprintSaved', true);
-                        let useProviderRoute = false;
-                        if (this.get('theme.isProvider')) {
-                            useProviderRoute = this.get('theme.isSubRoute');
-                        } else if (this.get('currentProvider.domain') && this.get('currentProvider.domainRedirectEnabled')) {
-                            window.location.replace(`${this.get('currentProvider.domain')}${model.id}`);
-                        } else if (this.get('currentProvider.id') !== 'osf') {
-                            useProviderRoute = true;
+                    const preprintId = model.get('id');
+                    // Fix for IN-271: Terrible kluge to reattach periodically lost primary files
+                    // that is likely due to a backend race condition in celery tasks.
+                    // The OSF api does not return null for empty to one relationships
+                    // which causes ember to not nullify the primaryFile relationship when it gets disconnected.
+                    // So the model needs to be unloaded, reloaded, reassigned, and saved
+                    // This resaving of the preprint should be removed (likely after node-preprint divorce)
+                    model.unloadRecord();
+                    this.get('store').findRecord('preprint', preprintId).then(m => {
+                        if(!this.get('editMode')) { 
+                            m.set('primaryFile', this.get('selectedFile'));
                         }
-                        this.transitionToRoute(
-                            `${useProviderRoute ? 'provider.' : ''}content`,
-                            model.reload()
-                        );
+                        m.save().then(() => {
+                            this.set('preprintSaved', true);
+                            if(isModerated) {
+                                const submitAction = this.get('store').createRecord('review-action', {
+                                    actionTrigger: 'submit',
+                                    target: m,
+                                });
+                                submitAction.save();
+                            }
+                            let useProviderRoute = false;
+                            if (this.get('theme.isProvider')) {
+                                useProviderRoute = this.get('theme.isSubRoute');
+                            } else if (this.get('currentProvider.domain') && this.get('currentProvider.domainRedirectEnabled')) {
+                                window.location.replace(`${this.get('currentProvider.domain')}${m.id}`);
+                            } else if (this.get('currentProvider.id') !== 'osf') {
+                                useProviderRoute = true;
+                            }
+                            this.transitionToRoute(`${useProviderRoute ? 'provider.' : ''}content`, m);
+                        })
+                    })
                 })
                 .catch(() => {
                     this.toggleProperty('shareButtonDisabled');

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1194,6 +1194,12 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
             this.set('providerSaved', true);
             this.send('discardSubjects');
             this.send('next', this.get('_names.0'));
+            Ember.get(this, 'metrics')
+                .trackEvent({
+                    category: 'button',
+                    action: 'click',
+                    label: `Submit - Save and continue, Select ${this.get('currentProvider.name')} preprint service`
+                });
         },
         discardProvider() {
             this.set('selectedProvider', this.get('currentProvider'));

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1464,6 +1464,7 @@ nav.branded-navbar {
     padding: 20px;
     margin-left: auto;
     margin-right: auto;
+    justify-content: center;
 
     .provider-logo-item {
         display: block;
@@ -1474,6 +1475,7 @@ nav.branded-navbar {
         background-repeat: no-repeat;
         background-position: center;
         min-width: 150px;
+        max-width: 150px;
         margin: 15px;
     }
 }

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -40,7 +40,17 @@
                     {{/unless}}
 
                     {{#with _names.[1] as |name|}}
-                        {{#preprint-form-section id='preprint-form-upload' editMode=editMode class="preprint-form-block" name=name allowOpen=(or providerSaved editMode) denyOpenMessage=(t 'submit.please_select_server') errorAction=(action 'error') as |hasOpened|}}
+                        {{#preprint-form-section
+                            id='preprint-form-upload'
+                            editMode=editMode
+                            class="preprint-form-block"
+                            name=name
+                            allowOpen=(or providerSaved editMode)
+                            open=(and theme.isProvider (not editMode))
+                            denyOpenMessage=(t 'submit.please_select_server')
+                            errorAction=(action 'error')
+                            as |hasOpened|
+                        }}
                             {{preprint-form-header editMode=editMode uploadSaveState=uploadSaveState showValidationIndicator=true name=name preprintNode=node preprintFile=model.primaryFile isValidationActive=(upload-validation-active editMode nodeLocked hasOpened) preprintTitle=node.title valid=(not uploadChanged)}}
                             {{#preprint-form-body}}
                                 {{#liquid-bind filePickerState class='translate' as |currentState|}}

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -1,4 +1,5 @@
-import { moduleFor, test, skip } from 'ember-qunit';
+import { moduleFor, skip } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 import Ember from 'ember';
 import moment from 'moment';
 import { manualSetup, mockFindAll } from 'ember-data-factory-guy';
@@ -33,6 +34,7 @@ const panelActionsStub = Ember.Service.extend({
     }
 });
 
+
 moduleFor('controller:submit', 'Unit | Controller | submit', {
     needs: [
         'validator:presence',
@@ -49,6 +51,8 @@ moduleFor('controller:submit', 'Unit | Controller | submit', {
         'model:file-version',
         'model:comment',
         'model:node',
+        'model:license',
+        'model:taxonomy',
         'model:preprint',
         'model:preprint-provider',
         'model:institution',
@@ -1087,4 +1091,41 @@ test('clickSubmit', function(assert) {
 
 skip('savePreprint', function() {
     //TODO
+});
+
+test('selectProvider', function(assert) {
+    const ctrl = this.subject();
+    this.inject.service('store');
+
+    Ember.run(() => {
+        const provider = this.store.createRecord('preprint-provider');
+
+        ctrl.set('provider', provider);
+        ctrl.send('selectProvider');
+
+        assert.strictEqual(ctrl.get('providerChanged'), true);
+    });
+
+});
+
+test('cancel', function(assert) {
+    const ctrl = this.subject();
+
+    ctrl.set('transitionToRoute', () => {});
+    const stub = this.stub(ctrl, 'transitionToRoute');
+
+    ctrl.send('cancel');
+    assert.ok(stub.calledOnce);
+
+    assert.ok(stub.calledWithExactly('index'));
+});
+
+test('returnToSubmission', function(assert) {
+    const ctrl = this.subject();
+
+    ctrl.set('transitionToRoute', () => {});
+    const stub = this.stub(ctrl, 'transitionToRoute');
+
+    ctrl.send('cancel');
+    assert.ok(stub.calledOnce);
 });


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
This is a stupid fix for an annoying problem that was surprisingly difficult to figure out: how do you resave something that the front end already believes is saved? h/t's to @jamescdavis, @laurenbarker, and @baylee-d for help along the way.

We believe that somewhere in the backend celery tasks there is a race condition that is causing preprint files to get lost sometimes. That race condition likely will go away with the Node-Preprint divorce because it likely is due to the interaction of saving nodes and preprints and getting stale data. The "simple" solution was to resave the data on the front end upon completion of the preprint. That's what this does... albeit less elegantly than I hoped. 

## Summary of Changes (And a journey)
1. After saving the preprint model and node, remove the preprint model from the ember store.
2. Refetch the preprint data from the api
3. Reassign the preprint file to the preprint
4. Save the preprint

## The Journey
1. Reassigning and saving a field on the model that it doesn't believe is dirty does change anything. I feel like this is generally expected, but is an important part of a fun issue later.
2. Reloading data on a model first fetches it from the store if possible, which means if it has it, it won't go back to the API to get fresh data.
3. You can add {reload: true} to a findRecord request to tell it to repull the data from the API. At this point I thought the problem would be nailed, but...
4. If a relationship is null, our API doesn't return anything for that relationship. JSON API spec says empty to one relationships should be null (see ticket James created: https://openscience.atlassian.net/browse/PLAT-840). 
5. On reloading the data, ember puts everywhere where it belongs, but does not prune or remove any relationships from the store that aren't returned (this is likely the correct behavior given JSON API spec).
6. This means that despite force reloading, the now null preprint file relationship still exists in the ember data store, so any attempts to reset the value of the relationship to the primary file are treated as a clean field and are not saved (point 1 coming back to bite). 
7. Until the backend is fixed to return empty to none as null, the solution is to unload the model in ember store, refetch the data from the API, assign the relationship value, and then save the now dirty field. 

Extras:
My first "working" solution broke post moderation because it tried to publish the preprint before reattaching the file. The logic had to be refactored mildly to get things to occur in the right order.


## Side Effects / Testing Notes
Test:
1. Test creating preprints on each variation of moderated services (osf no moderation, premod, and post mod)
2. Test editing a preprint after each of those variations to ensure it saves properly when done editing.


## Ticket

https://openscience.atlassian.net/browse/IN-271

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
