### PR TITLE
[IN-235][Preprints] Fix navbar on branded domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Styling and format of the branded navbar to match current styling in ember-osf
+
 ## [0.118.5] - 2018-04-27
 ### Changed
 - Updated to use latest provider assets

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1335,18 +1335,17 @@ nav.preprint-navbar {
     .nav-user-dropdown {
         height: $nav-height;
     }
-
-    .dropdown > a {
-        padding-top: 12px;
-        padding-bottom: 12px;
-    }
-
+    
     .dropdown-menu {
         color: white;
     }
 
     .sign-in {
         padding-top: 8px;
+    }
+
+    .navbar-title {
+        padding-right: 50px;
     }
 }
 

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -1,17 +1,17 @@
 <div class="container">
     <div class="navbar-header">
-        <button type="button" class="navbar-toggle" id='preprint-branded-collapse-button' data-toggle="collapse" aria-label={{t 'components.preprint-navbar.toggle'}} data-target="#preprint-navbar-links">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-        </button>
         <a class="navbar-brand" href='{{theme.pathPrefix}}'
             onclick={{action "click" "link" "Navbar - Brand"}}>
             <span class="navbar-image" style={{safe-markup (concat "background-image: url('" (provider-asset theme.id 'square_color_transparent.png') "')")}}></span>
             <span class="navbar-title">{{model.name}}{{#if theme.preprintWordInTitle}} {{t "global.preprints"}}{{/if}}</span>
         </a>
+        <a type="button" role="button" class="navbar-toggle collapsed" id="preprint-branded-collapse-button" data-toggle="collapse" data-target="#secondary-navigation" aria-label={{t 'components.preprint-navbar.toggle'}}>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </a>
     </div>
-    <div id="preprint-navbar-links" class="navbar-collapse collapse navbar-right">
+    <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
         <ul class="nav navbar-nav branded-nav">
             {{#if session.isAuthenticated}}
                 <li><a href="{{host}}myprojects/" class="" onbeforeclick={{action "click" "link" "Navbar - My OSF Projects"}}>{{t "components.preprint-navbar-branded.my_projects"}}</a></li>


### PR DESCRIPTION
## Purpose

The branded navbar's styling doesn't match what is seen in ember-osf and osf.io

## Summary of Changes

- Change formatting/classes/id's in `preprint-navbar-branded` to match what's required for osf-style
- Remove unnecessary padding and add padding to the logo to prevent squishy-ness on smaller screens with long names

## Side Effects / Testing Notes

This should make the branded navbar act the same way as the navbar on ember-osf apps and osf.io.
- It should cut off long user names and prevent it from breaking to a new line/run off the screen
- It should also keep cutting the name as the screen gets smaller
- Because this is branded, it should keep the old styling that's specific for the provider

** Note **
This should be used with the PR for the ember-osf side:
https://github.com/CenterForOpenScience/ember-osf/pull/387

![navbar](https://user-images.githubusercontent.com/19379783/40247614-fcf94364-5a9a-11e8-9485-944b7923d5a7.gif)

## Ticket

https://openscience.atlassian.net/browse/IN-235

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
