### PR TITLE
[IN-309][Preprints] Fix deleting tags

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -880,7 +880,7 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
         },
 
         // Custom removeATag method that removes tag from list instead of auto-saving
-        removeTag(index) {
+        removeTag(tag) {
             this.get('metrics')
                 .trackEvent({
                     category: 'button',
@@ -888,7 +888,7 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
                     label: `${this.get('editMode') ? 'Edit' : 'Submit'} - Remove Tag`,
                 });
 
-            this.get('basicsTags').removeAt(index);
+            this.get('basicsTags').removeObject(tag);
         },
 
         /*

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -1052,7 +1052,7 @@ test('addTag', function(assert) {
 test('removeTag', function(assert) {
     const ctrl = this.subject();
     ctrl.set('basicsTags', ['firstTag', 'secondTag']);
-    ctrl.send('removeTag', 1);
+    ctrl.send('removeTag', 'secondTag');
     assert.equal(ctrl.get('basicsTags').length, 1);
     assert.equal(ctrl.get('basicsTags')[0], 'firstTag');
 });


### PR DESCRIPTION
## Purpose
Fix deleting tags when adding a preprint

Fix issue where tags are deleted from the tags box but the controller still
keeps the tags.

## Summary of Changes

Fix the action handling removeTag to use arg as `tag` not `index`

## Side Effects / Testing Notes


## Ticket

[[IN-309]](https://openscience.atlassian.net/browse/IN-309)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`