### PR TITLE
[IN-306][Preprints] Fix bug on external branded preprint domains

### DIFF
--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -74,7 +74,7 @@ export default CpPanelComponent.extend(Analytics, {
                     });
                 this._super(...arguments);
             } else {
-                this.errorAction(this.denyOpenMessage);
+                this.sendAction('errorAction', this.denyOpenMessage); // eslint-disable-line ember/closure-actions
             }
         } else {
             /* Manual animation

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,7 +26,7 @@ export default Route.extend(Analytics, OSFAgnosticAuthRouteMixin, {
                             domain: `${window.location.origin}/`,
                         },
                     },
-                ).then(this.setTheme(this));
+                ).then(this.setTheme.bind(this));
             }
         };
         const parentResult = this._super(...arguments);


### PR DESCRIPTION
## Purpose

External preprint domains aren't getting the right theme properties.

## Summary of Changes

- Fix small bug that wasn't binding `this` when attaching the branded domain's theme
- Revert error action to use `sendAction` as an eslint exception

## Side Effects / Testing Notes

This should fix external domains.  Namely fixes two big issues:
- Preprints were infinitely reloading (between the domain and the osf domain like staging-osf)
- Provider carousel was appearing on the submit page of branded domains

## Ticket

https://openscience.atlassian.net/browse/IN-306

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
