### PR TITLE
[IN-315][Preprints] Fix preprint warning modal

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -164,7 +164,7 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     // Preuploaded file - file that has been dragged to dropzone, but not uploaded to node.
     selectedFile: null,
     // File that will be the preprint (already uploaded to node or selected from existing node)
-    title: null,
+    title: '',
     // Preprint title
     nodeLocked: false,
     // the node is locked.  Is True on Edit.
@@ -287,7 +287,8 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     // True if fields have been changed
     hasDirtyFields: computed('theme.isProvider', 'hasFile', 'preprintSaved', 'isAddingPreprint', 'providerSaved', 'uploadChanged', 'basicsChanged', 'disciplineChanged', function() {
         const preprintStarted = this.get('theme.isProvider') ? this.get('hasFile') : this.get('providerSaved');
-        return !this.get('preprintSaved') && ((this.get('isAddingPreprint') && preprintStarted) || this.get('uploadChanged') || this.get('basicsChanged') || this.get('disciplineChanged'));
+        const fieldsChanged = this.get('uploadChanged') || this.get('basicsChanged') || this.get('disciplineChanged');
+        return !this.get('preprintSaved') && ((this.get('isAddingPreprint') && preprintStarted) || fieldsChanged);
     }),
 
     // Relevant in Add mode - flag prevents users from sending multiple requests to server
@@ -311,7 +312,6 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     }),
 
     // Pending abstract
-
     basicsAbstract: computed('model.description', function() {
         return this.get('model.description') || null;
     }),
@@ -1388,7 +1388,7 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
             file: null,
             selectedFile: null,
             contributors: A(),
-            title: null,
+            title: '',
             nodeLocked: false, // Will be set to true if edit?
             searchResults: [],
             savingPreprint: false,

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -25,9 +25,10 @@ export default Route.extend(ConfirmationMixin, ResetScrollMixin, CasAuthenticate
     }),
     model() {
         // Store the empty preprint to be created on the model hook for page. Node will be fetched
-        //  internally during submission process.
+        // internally during submission process.
         return this.get('store').createRecord('preprint', {
             subjects: [],
+            title: '',
         });
     },
     afterModel() {

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -111,7 +111,7 @@ test('Initial properties', function (assert) {
         file: null,
         selectedFile: null,
         'contributors.length': 0,
-        title: null,
+        title: '',
         nodeLocked: false,
         'searchResults.length': 0,
         savingPreprint: false,
@@ -863,7 +863,7 @@ test('discardUploadChanges', function(assert) {
         ctrl.set('model', preprint);
         assert.equal(ctrl.get('file'), null);
         assert.equal(ctrl.get('selectedFile'), null);
-        assert.equal(ctrl.get('title'), null);
+        assert.equal(ctrl.get('title'), '');
         assert.equal(ctrl.get('titleValid'), null);
         ctrl.send('discardUploadChanges');
         assert.equal(ctrl.get('file'), null);


### PR DESCRIPTION
## Purpose
The submit page shows a warning modal on navigation even if you haven't done anything.


## Summary of Changes
* Switched title default to `''` instead of `null` to prevent a false positive when checking equality (e.g., null === undefined returns false). 
* Split some of the long line into a variable so it's easier to read

Generally the defaults should match the type that will be in that field to prevent this kind of thing.


## Side Effects / Testing Notes
None expected


## Ticket

https://openscience.atlassian.net/browse/IN-315

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md` (should this go in the CHANGELOG?)

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
