### PR TITLE
[IN-198][Preprints] Node parent title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.118.4] - 2018-04-05
 ### Fixed
 - Automatic opening of upload section on branded provider submit page
+- Correctly show parent projects in the "Choose project" dropdown
 
 ### Removed
 - Unused image code

--- a/app/components/preprint-form-project-select.js
+++ b/app/components/preprint-form-project-select.js
@@ -184,6 +184,7 @@ export default Component.extend(Analytics, {
                 preprint: false,
                 title: searchTerm,
             },
+            embed: 'parent',
         });
         // When the promise finishes, set the searchTerm
         this.set('searchTerm', searchTerm);
@@ -207,6 +208,7 @@ export default Component.extend(Analytics, {
                 preprint: false,
                 title: searchTerm,
             },
+            embed: 'parent',
         });
         const userNodes = this.get('userNodes');
         let onlyAdminNodes = results.results.filter(item => item.get('currentUserPermissions').includes(Permissions.ADMIN));


### PR DESCRIPTION
## Purpose
Node parents sometimes show as private when searching for a project.

## Summary of Changes

Embed node parent to allow parent title's to appear in the select project dropdown

## Side Effects / Testing Notes
Alex notes: Make sure that parents of projects don't say private when not private (see issue description). There are two functions that fetch the data, one for the first fetch and one for every fetch after. So make sure both the first fetch of data works and additional filtering works. Ask me (alex) if that isn't clear.


## Ticket

https://openscience.atlassian.net/browse/IN-198

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
