### PR TITLE
[IN-255][Preprints] Use "OSF Preprints"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unified solution for preprint words
 - use of ember-osf `scheduled-banner` component
 - Selected provider description in the provider carousel
+- use of "OSF Preprints" as provider name for OSF preprints instead of "OSF" or "Open Science Framework"
 
 ### Changed
 - Styling and format of the branded navbar to match current styling in ember-osf

--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -56,7 +56,7 @@ export default Component.extend(Analytics, {
         const providerNames = providers.filter(provider => provider.get('id') !== 'livedata').map((provider) => {
             const name = provider.get('shareSource') || provider.get('name');
             // TODO Change this in populate_preprint_providers script to just OSF
-            return name === 'Open Science Framework' ? 'OSF' : name;
+            return name === 'Open Science Framework' ? 'OSF Preprints' : name;
         });
         this.set('osfProviders', providerNames);
         return providerNames;
@@ -67,7 +67,7 @@ export default Component.extend(Analytics, {
 
     _formatProviderWhitelist([osfProviders, hits]) {
         // Get the whitelist and add the OSF Providers to it
-        const whiteList = this.get('whiteListedProviders')
+        const whiteList = (this.get('whiteListedProviders') || [])
             .map(provider => provider.toLowerCase())
             .concat(osfProviders
                 .map(osfProvider => osfProvider.toLowerCase()));

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -34,7 +34,7 @@ export default Controller.extend(Analytics, {
     },
     // TODO: Add a conversion from shareSource to provider names here if desired
     filterReplace: { // Map filter names for front-end display
-        'Open Science Framework': 'OSF',
+        'Open Science Framework': 'OSF Preprints',
         'Cognitive Sciences ePrint Archive': 'Cogprints',
         OSF: 'OSF Preprints',
         'Research Papers in Economics': 'RePEc',

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -286,10 +286,6 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
 
     moderationType: alias('currentProvider.reviewsWorkflow'),
 
-    isOSFPreprints: computed('selectedProvider', function() {
-        return this.get('selectedProvider') && this.get('selectedProvider.name') === 'Open Science Framework';
-    }),
-
     // True if fields have been changed
     hasDirtyFields: computed('theme.isProvider', 'hasFile', 'preprintSaved', 'isAddingPreprint', 'providerSaved', 'uploadChanged', 'basicsChanged', 'disciplineChanged', function() {
         const preprintStarted = this.get('theme.isProvider') ? this.get('hasFile') : this.get('providerSaved');

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -150,7 +150,7 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
         const dateCreated = new Date(preprint.get('dateCreated') || null);
         const dateModified = new Date(preprint.get('dateModified') || dateCreated);
         if (!preprint.get('datePublished')) { preprint.set('datePublished', dateCreated); }
-        const providerName = provider.get('name');
+        const providerName = provider.get('name') === 'Open Science Framework' ? 'OSF Preprints' : provider.get('name');
         const canonicalUrl = preprint.get('links.html');
         const contributors = this.get('contributors');
         const downloadUrl = this.get('downloadUrl');

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -26,7 +26,7 @@
             <em class="m-r-md"> {{t "components.preprint-form-header.server" documentType=provider.documentType}}: </em>
             {{#if currentProvider}}
                 <img alt="provider logo" class="current-provider" title="{{currentProvider.name}}" src={{provider-asset currentProvider.id 'square_color_no_transparent.png'}}>
-                {{currentProvider.name}}
+                {{if (not theme.isProvider) 'OSF Preprints' currentProvider.name}}
             {{/if}}
         </p>
     </div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -27,7 +27,7 @@
                                         <div class="row">
                                             <div style="padding: 25px 85px 15px;" class="col-md-12">
                                                 <dl class="dl-horizontal dl-description">
-                                                    <dt>{{if isOSFPreprints 'OSF Preprints' selectedProvider.name}}:</dt>
+                                                    <dt>{{if (not theme.isProvider) 'OSF Preprints' selectedProvider.name}}:</dt>
                                                     <dd>{{sanitize-html selectedProvider.description}}</dd>
                                                 </dl>
                                             </div>


### PR DESCRIPTION
## Purpose

Use "OSF Preprints" instead of "Open Science Framework"

## Summary of Changes
- Update search provider facet to use "OSF Preprints" (on discover page)
- Update `filterReplace` to sub with "OSF Preprints"  in lieu of "OSF"
- Fixed `whiteListedProviders` to handle case where is still `undefined`

## Side Effects / Testing Notes

Please make sure that 
- the search provider facet on discover page left pane uses "OSF Preprints"
- on submit page, after selecting OSF Preprints and moving on to the next section, it shows "OSF Preprints"
- on preprint detail page, the publisher head meta tags use "OSF Preprints" for osf preprints.

## Ticket

[IN-255](https://openscience.atlassian.net/browse/IN-255)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
