### PR TITLE
[IN-180][Preprints] Track custom dimensions in Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - use of ember-osf `scheduled-banner` component
 - Selected provider description in the provider carousel
 - use of "OSF Preprints" as provider name for OSF preprints instead of "OSF" or "Open Science Framework"
+- parameters for `authenticated`, `isPublic` and `resource` to pageView tracking
 
 ### Changed
 - Styling and format of the branded navbar to match current styling in ember-osf

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ const Router = EmberRouter.extend({
     rootURL: config.rootURL,
     metrics: service(),
     theme: service(),
+    session: service(),
 
     didTransition() {
         this._super(...arguments);
@@ -17,10 +18,32 @@ const Router = EmberRouter.extend({
 
     _trackPage() {
         run.scheduleOnce('afterRender', this, () => {
+            // Tracks page with custom parameters
+            // authenticated => if the user is logged in or not
+            // isPublic      => if the resource the user is viewing is public or private.
+            //                  n/a is used for pages like discover and index
+            // page          => the name of the current page
+            // resource      => what resource the user is on. Ex node, preprint, registry.
+            // title         => the current route name
+            const {
+                authenticated,
+                isPublic,
+                resource,
+            } = config.metricsAdapters[0].dimensions;
+
             const page = document.location.pathname;
             const title = this.getWithDefault('currentRouteName', 'unknown');
+            const isAuthenticated = this.get('session.isAuthenticated');
+            const publicType = title.endsWith('content.index') ? 'public' : 'n/a';
+            const modelType = title.endsWith('content.index') ? 'preprint' : 'n/a';
 
-            this.get('metrics').trackPage({ page, title });
+            this.get('metrics').trackPage({
+                [authenticated]: isAuthenticated ? 'Logged in' : 'Logged out',
+                [isPublic]: publicType,
+                page,
+                [resource]: modelType,
+                title,
+            });
             this.set('theme.currentLocation', window.location.href);
         });
     },

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,6 +48,11 @@ module.exports = function(environment) {
                 config: {
                     id: process.env.GOOGLE_ANALYTICS_ID,
                 },
+                dimensions: {
+                    authenticated: 'dimension1',
+                    resource: 'dimension2',
+                    isPublic: 'dimension3',
+                },
             },
             {
                 name: 'Keen',

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ember-i18n": "^5.0.2",
     "ember-link-action": "^0.0.36",
     "ember-load-initializers": "^1.0.0",
-    "ember-metrics": "^0.6.3",
     "ember-moment": "^7.4.1",
     "ember-onbeforeunload": "^1.1.2",
     "ember-page-title": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3939,7 +3939,7 @@ ember-get-config@^0.2.3, ember-get-config@^0.2.4:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
 
-ember-getowner-polyfill@^1.0.0, ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.2:
+ember-getowner-polyfill@^1.1.0, ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.5.tgz#ceff8a09897d0d7e05c821bb71666a95eb26dc92"
   dependencies:
@@ -4051,15 +4051,6 @@ ember-metrics@^0.12.1:
     ember-cli-babel "^6.1.0"
     ember-getowner-polyfill "^2.0.0"
     ember-runtime-enumerable-includes-polyfill "^2.0.0"
-
-ember-metrics@^0.6.3:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-0.6.4.tgz#ae09db7a40081df538463c5b5b3ac3da48c94027"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    ember-cli-babel "^5.1.6"
-    ember-getowner-polyfill "^1.0.0"
-    ember-runtime-enumerable-includes-polyfill "^1.0.1"
 
 ember-moment@^7.4.1:
   version "7.7.0"
@@ -4183,13 +4174,6 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   resolved "https://registry.yarnpkg.com/ember-router-generator/-/ember-router-generator-1.2.3.tgz#8ed2ca86ff323363120fc14278191e9e8f1315ee"
   dependencies:
     recast "^0.11.3"
-
-ember-runtime-enumerable-includes-polyfill@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-1.0.4.tgz#16a7612e347a2edf07da8b2f2f09dbfee70deba0"
-  dependencies:
-    ember-cli-babel "^5.1.6"
-    ember-cli-version-checker "^1.1.6"
 
 ember-runtime-enumerable-includes-polyfill@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Purpose

To add custom dimensions to our `trackPage` function.

## Summary of Changes

- Add `authorized`, `resource`, and `isPublic` dimensions to the `trackPage` function
- Remove old version of `ember-metrics` since we're getting a newer version from `ember-osf`

## Side Effects / Testing Notes

There should be three new dimensions that you see in a trackPage request:

If the page is discover, index, or submit/edit:
authorized => [whether or not the user is logged in will be true or false]
isPublic => [n/a]
resource => [n/a]

If the page is content/detail page:
authorized => [whether or not the user is logged in will be true or false]
isPublic => [public]
resource => [preprint]

## Ticket

https://openscience.atlassian.net/browse/IN-180

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
