### PR TITLE
[IN-305][Preprints] Both check and disable box if theme.isProvider

### DIFF
--- a/app/templates/components/search-facet-provider.hbs
+++ b/app/templates/components/search-facet-provider.hbs
@@ -3,7 +3,7 @@
         {{#each otherProviders as |item|}}
             <li>
                 <label>
-                    <input type="checkbox" checked="{{if (if-filter item.key state.value) 'checked'}}" onclick={{action updateFilters 'provider' item.key}} disabled={{theme.isProvider}}>
+                    <input type="checkbox" checked="{{if (or (if-filter item.key state.value) theme.isProvider) 'checked'}}" onclick={{action updateFilters 'provider' item.key}} disabled={{theme.isProvider}}>
                     {{filter-replace item.key filterReplace}}
                     <small>({{number-format item.doc_count}})</small>
                 </label>


### PR DESCRIPTION
## Purpose
Check box in the provider facet for branded provider on the discover page.


## Summary of Changes
Before:
<img width="362" alt="unchecked-branded-provider" src="https://user-images.githubusercontent.com/7131985/42055501-53302d28-7ae5-11e8-9460-ca9a8a0662f0.png">

After:
![checked-provider-facet](https://user-images.githubusercontent.com/7131985/42055510-58b54c42-7ae5-11e8-82f9-1f5316b8d4cc.png)


## Side Effects / Testing Notes
Check that the provider is checked when it should be and not when it shouldn't be. Probably covered in general regression testing.


## Ticket

https://openscience.atlassian.net/browse/IN-305

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
