### PR TITLE
[No Ticket][Preprints] Pass documentType to abstract placeholder translation

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -219,7 +219,7 @@
                                             <span class="required">{{t "global.abstract"}}:</span>
                                         </label>
                                         <form onchange={{if editMode (action 'track' 'input' 'onchange' 'Edit - Abstract Text Change') (action 'track' 'input' 'onchange' 'Submit - Abstract Text Change')}}>
-                                            {{validated-input inputType='textarea' model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder") value=basicsAbstract}}
+                                            {{validated-input inputType='textarea' model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder" documentType=currentProvider.documentType) value=basicsAbstract}}
                                         </form>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Purpose
Missing preprint word.

## Summary of Changes/Side Effects
Before:
<img width="453" alt="missing-preprint-word" src="https://user-images.githubusercontent.com/7131985/42381799-38d05112-8100-11e8-82a1-31db1e6bcb17.png">

## Testing Notes
Make sure preprint word is present in abstract placeholder.


## Ticket
No ticket

## Notes for Reviewer
Did not test this locally.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
