### PR TITLE
[No ticket] Preprint word hotfix

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -183,7 +183,7 @@
                                             <div class='col-xs-12'>
                                                 <label> {{t "submit.body.basics.license.apply_license_title"}} </label>
                                                 {{#if (or (not newNode) editMode)}}
-                                                    <p>{{t "submit.body.basics.license.apply_license_text" documentType=currentProvider.documentType}}</p>
+                                                    <p>{{t "submit.body.basics.license.apply_license_text" documentType=model.provider.content.documentType}}</p>
                                                 {{/if}}
                                                 <span style="margin: 5px">
                                                     <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
@@ -295,7 +295,7 @@
                                 </div>
                             {{/if}}
                             <button class="btn btn-primary btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'returnToSubmission'}}>
-                                {{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}
+                                {{t "submit.body.edit.return_button" documentType=model.provider.content.documentType}}
                             </button>
                         </div>
                     {{else}}


### PR DESCRIPTION
## Purpose

Fix missing preprint word on preprint edit page.


## Summary of Changes/Side Effects
In edit mode, `currentProvider` is not set, causing the page to not get the preprint word properly.
Therefore, `currentProvider` is changed to `model.provider.content` for translations on edit page.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
