### PR TITLE
[IN-365][Preprints] Fix submit preprint from discover page redirect error

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -374,10 +374,10 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
                 this.get('model.licenseRecord.copyright_holders').join(', ') :
                 '') !== this.get('basicsLicense.copyrightHolders')) return true;
         } else {
-            if ((this.get('availableLicenses').toArray().length ?
+            if (this.get('basicsLicense.licenseType.name') && (this.get('availableLicenses').toArray().length ?
                 this.get('availableLicenses').toArray()[0].get('name') :
                 null) !== this.get('basicsLicense.licenseType.name')) return true;
-            if ((new Date()).getUTCFullYear().toString() !== this.get('basicsLicense.year')) return true;
+            if (this.get('basicsLicense.year') && (new Date()).getUTCFullYear().toString() !== this.get('basicsLicense.year')) return true;
             if (!(this.get('basicsLicense.copyrightHolders') === '' ||
                 !this.get('basicsLicense.copyrightHolders.length') ||
                 this.get('basicsLicense.copyrightHolders') === null)) return true;

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -538,8 +538,7 @@ test('licenseChanged with no model set', function(assert) {
             copyrightHolders: 'Sally Ride',
             licenseType: $.extend(true, {}, license),
         };
-        // TODO is below assertion correct?
-        assert.equal(ctrl.get('licenseChanged'), true);
+        assert.equal(ctrl.get('licenseChanged'), false);
         assert.equal(ctrl.get('basicsLicense.licenseType.name'), null);
         ctrl.set('basicsLicense', basicsLicense);
         assert.equal(ctrl.get('licenseChanged'), true);


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
<!-- Why is this change necessary? What does it do? -->
Clicking the Sidebar add preprint button on the discover page while not logged throws a prompt from the discover page for dirty fields on the submit page. If you reject this redirect (to the login page) you will be able to stay on a broken not logged in submit page. 

## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
Fixed fields that are dirty before the model is properly set so the dirty fields should not trigger the page change confirmation dialogue. This should prevent the bad behavior. 

Code wise, I added checks for basicsLicense name and year needing to not be null for them to be dirty. The year cannot be nullified through the UI (backspacing the whole 2018 resets it back to the current year) and the license name should never be a proper null value. 

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->
1. Confirm no redirect confirmation when pressing the button.
2. Regression of the dirty fields confirmation. Changing things should still trigger the dirty fields page change dialogue, not changing things shouldn't, etc. 

## Ticket

https://openscience.atlassian.net/browse/IN-365

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->
I changed one test that had a weird TODO that made it clear they didn't know what the intended behavior was. I'm pretty my change is right, but worth considering. 

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
