### PR TITLE
[IN-261][Preprints] Fix navbar small screens 

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1337,6 +1337,17 @@ nav.preprint-navbar {
         margin-right: 16px;
     }
 
+    // Hacks for very small preprints windows breaking navbar into two lines
+    // Don't display the preprint word on small screens and force the margin of the button over a bit
+    @media (max-width: 520px) {
+        .navbar-preprint-word {
+            display: none;
+        }
+        #preprint-branded-collapse-button {
+            margin-right: -15px;
+        }
+    }
+
     .nav-user-dropdown {
         height: $nav-height;
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1339,6 +1339,8 @@ nav.preprint-navbar {
 
     // Hacks for very small preprints windows breaking navbar into two lines
     // Don't display the preprint word on small screens and force the margin of the button over a bit
+    // The margin hack should be removed in this ticket: https://openscience.atlassian.net/browse/IN-368]
+    // the preprint word display:none will probably need to stay
     @media (max-width: 520px) {
         .navbar-preprint-word {
             display: none;

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -3,7 +3,7 @@
         <a class="navbar-brand" href='{{theme.pathPrefix}}'
             onclick={{action "click" "link" "Navbar - Brand"}}>
             <span class="navbar-image" style={{safe-markup (concat "background-image: url('" (provider-asset theme.id 'square_color_transparent.png') "')")}}></span>
-            <span class="navbar-title">{{model.name}}{{#if theme.preprintWordInTitle}} {{t "global.preprints" documentType=theme.provider.content.documentType}}{{/if}}</span>
+            <span class="navbar-title">{{model.name}}{{#if theme.preprintWordInTitle}}<span class="navbar-preprint-word"> {{t "global.preprints" documentType=theme.provider.content.documentType}}</span>{{/if}}</span>
         </a>
         <a type="button" role="button" class="navbar-toggle collapsed" id="preprint-branded-collapse-button" data-toggle="collapse" data-target="#secondary-navigation" aria-label={{t 'components.preprint-navbar.toggle'}}>
             <span class="icon-bar"></span>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
<!-- Why is this change necessary? What does it do? -->
Preprints breaks on small screens on providers with long names
We lost some margin on the right with recent changes.

Production:
<img width="401" alt="screen shot 2018-07-19 at 2 43 55 pm" src="https://user-images.githubusercontent.com/1322421/43008983-72f8c670-8c0a-11e8-88bb-bbb54f550456.png">

Left: Staging1
Right: Staging2
<img width="802" alt="screen shot 2018-07-19 at 2 36 09 pm" src="https://user-images.githubusercontent.com/1322421/43009001-7fbd83b4-8c0a-11e8-9c88-0fc0640feb20.png">


## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
1. Remove the preprint word at very small sizes (<520px, arbitrary point that worked)
2. Remove some extra margin at small sizes (dumb I know, I feel bad doing it this way). 

![lis](https://user-images.githubusercontent.com/1322421/43009133-cadb33dc-8c0a-11e8-8b89-8da438f0bbd2.gif)


## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->
Check long providers at breakpoints to make sure they still look good on test. None should break now.


## Ticket

https://openscience.atlassian.net/browse/IN-261

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
