### PR TITLE
[IN-261][Preprints] Fix collapsible panel animation on submit/edit page

### DIFF
--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -76,31 +76,6 @@ export default CpPanelComponent.extend(Analytics, {
             } else {
                 this.sendAction('errorAction', this.denyOpenMessage); // eslint-disable-line ember/closure-actions
             }
-        } else {
-            /* Manual animation
-             * Can be omitted if using {{cp-panel-body}} instead of {{preprint-form-body}} because
-             * cp-panel-body uses liquid-if for animation. preprint-form-body purposely avoids
-             * liquid-if because liquid-if will cause elements to be removed from DOM.
-             * This is can cause some information to be lost (e.g. dropzone state).
-             */
-            if (this.get('animate')) {
-                return;
-            }
-            const $body = this.$('.cp-Panel-body');
-            if (this.get('isOpen')) {
-                $body.height('auto');
-                $body.height($body.height());
-                $body.one('transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd', () => {
-                    $body.addClass('no-transition');
-                    $body.height('');
-                    $body.removeClass('no-transition');
-                });
-            } else {
-                $body.addClass('no-transition');
-                $body.height($body.height());
-                $body.removeClass('no-transition');
-                $body.height('');
-            }
         }
     },
 });


### PR DESCRIPTION
## Purpose
The collapsible panel on the submit/edit page is currently broken for the Upload section.  When clicked, the panel doesn't collapse and instead just gets obnoxiously tall.


## Summary of Changes/Side Effects
- Removed code that changed the height of the internal elements on click


## Testing Notes
The issue was that the Upload section's height would grow really tall when clicked a second time when it was already opened.

On the submit/edit page:
- Fill out the upload section and continue
- Click on the upload section again, make sure it works as expected.  Make sure that all of the internal collapsible panels open and close properly.
- Click on the upload section one more time.  It shouldn't collapse or expand, and it should stay the same height.

This can also affect the other panels, so please be sure to also test this on all of the other panels on the page to make sure they all work as expected.


## Ticket

https://openscience.atlassian.net/browse/IN-261

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
