### PR TITLE
[IN-180][Preprints] Fix environment variable check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sharing from the preprint detail view to use ember-osf sharing icons
 - Update preprints to work with a new unified version of ember-osf (works with both preprints and reviews apps)
 - Update preprints to use ember-cli@2.18
+- Environment check in `config/environment`
 
 ## [0.119.0] - 2018-07-16
 ### Added

--- a/config/environment.js
+++ b/config/environment.js
@@ -44,7 +44,7 @@ module.exports = function(environment) {
         metricsAdapters: [
             {
                 name: 'GoogleAnalytics',
-                environments: [process.env.KEEN_ENVIRONMENT] || ['production'],
+                environments: [process.env.KEEN_ENVIRONMENT || 'production'],
                 config: {
                     id: process.env.GOOGLE_ANALYTICS_ID,
                     setFields: {
@@ -60,7 +60,7 @@ module.exports = function(environment) {
             },
             {
                 name: 'Keen',
-                environments: [process.env.KEEN_ENVIRONMENT] || ['production'],
+                environments: [process.env.KEEN_ENVIRONMENT || 'production'],
                 config: {
                     private: {
                         projectId: process.env.PREPRINTS_PRIVATE_PROJECT_ID,


### PR DESCRIPTION
## Purpose
As noted in https://github.com/CenterForOpenScience/ember-osf-preprints/issues/459, the original environment check that we were doing would always evaluate the first check as an array and would always be truthy.  This would prevent the second part from being checked.


## Summary of Changes/Side Effects
Changed:
`[process.env.KEEN_ENVIRONMENT] || ['production']`
to:
`[process.env.KEEN_ENVIRONMENT || 'production']`


## Testing Notes
This shouldn't have any noticeable affects on the front end.  You should still be able to see Google Analytics and Keen working normally.


## Ticket
https://openscience.atlassian.net/browse/IN-180


## Notes for Reviewer
`N/A`


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
