### PR TITLE
[Noticket] Fix discover page for branded providers.

### DIFF
--- a/app/routes/provider/discover.js
+++ b/app/routes/provider/discover.js
@@ -3,9 +3,10 @@ import route from '../discover';
 route.reopen({
     controllerName: 'discover',
     renderTemplate(controller, model) {
+        const providers = model.preprintProviders;
         this.render('discover', {
             controller,
-            model,
+            providers,
         });
     },
 });


### PR DESCRIPTION
## Purpose

Fix the problem where discover pages for branded providers are not loading.


## Summary of Changes/Side Effects

In `route/provider/discover.js`, the model for the controller is set to `model.preprintProviders` because the `model` hook in `route/discover.js` has changed from returning the result of the `query` to returning a object whose `preprintProviders` contains the result.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
