### PR TITLE
[IN-117] Change discover page button

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -105,7 +105,8 @@ export default {
             tag: 'Tag',
             box: {
                 paragraph: 'Do you want to add your own research as a {{documentType.singular}}?',
-                button: 'Add your {{documentType.singular}}',
+                button_non_moderated: 'Add a {{documentType.singular}}',
+                button_moderated: 'Submit a {{documentType.singular}}',
             },
             results: {
                 of: 'of',

--- a/app/templates/components/add-preprint-box.hbs
+++ b/app/templates/components/add-preprint-box.hbs
@@ -4,7 +4,11 @@
        type="button" class="btn btn-success btn-lg"
        invokeAction=(action 'click' 'button' 'Discover - Add Preprint')
     }}
-        {{t "discover.main.box.button" documentType=provider.documentType}}
+        {{#if theme.provider.reviewsWorkflow}}
+            {{t "discover.main.box.button_moderated" documentType=provider.documentType}}
+        {{else}}
+            {{t "discover.main.box.button_non_moderated" documentType=provider.documentType}}
+        {{/if}}
     {{/link-to}}
 </div>
 

--- a/tests/integration/components/add-preprint-box-test.js
+++ b/tests/integration/components/add-preprint-box-test.js
@@ -1,15 +1,43 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
+import Service from '@ember/service';
+
+const fakeProvider = {
+    reviewsWorkflow: 'pre-moderation',
+    id: 'pandaXriv',
+    name: 'The Panda Archive of bamboo',
+    isProvider: true,
+};
+
+// Stub theme service
+const themeStub = Service.extend({
+    provider: fakeProvider,
+    signupUrl: 'fakeUrl',
+    redirectUrl: 'fakeUrl',
+    pathPrefix: 'fakePrefix',
+    id: 'pandaXriv',
+});
 
 moduleForComponent('add-preprint-box', 'Integration | Component | add preprint box', {
     integration: true,
+    beforeEach() {
+        this.register('service:theme', themeStub);
+    },
 });
 
 test('it renders', function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.on('myAction', function(val) { ... });
-
-    this.render(hbs`{{add-preprint-box}}`);
-
-    assert.strictEqual(this.$('p')[0].textContent, 'Do you want to add your own research as a ?'); // preprint words needs to be run with ember osf
+    this.inject.service('store');
+    run(() => {
+        const provider = this.store.createRecord('preprint-provider', {
+            documentType: {
+                singular: 'faker',
+            },
+        });
+        this.set('provider', provider);
+        this.render(hbs`{{add-preprint-box}}`);
+        assert.strictEqual(this.$('p')[0].textContent, 'Do you want to add your own research as a ?'); // preprint words needs to be run with ember osf
+    });
 });


### PR DESCRIPTION
## Purpose

We miss the button for discover page when changing the languages.

## Summary of Changes/Side Effects

For the discover page, `Add your preprint` button is changed to `Add a preprint` for non-moderated providers and `Submit a preprint` for moderated providers.

## Ticket

https://openscience.atlassian.net/browse/IN-117

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
