### PR TITLE
[IN-353][Preprints] Fix facet filter for OSF Preprints

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -55,7 +55,7 @@ export default Component.extend(Analytics, {
         const providerNames = providers.filter(provider => provider.get('id') !== 'livedata').map((provider) => {
             const name = provider.get('shareSource') || provider.get('name');
             // TODO Change this in populate_preprint_providers script to just OSF
-            return name === 'Open Science Framework' ? 'OSF Preprints' : name;
+            return name === 'Open Science Framework' ? 'OSF' : name;
         });
         this.set('osfProviders', providerNames);
         return providerNames;

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -128,7 +128,6 @@ export default Controller.extend(Analytics, discoverQueryParams.Mixin, {
 
     // TODO: Add a conversion from shareSource to provider names here if desired
     filterReplace: { // Map filter names for front-end display
-        'Open Science Framework': 'OSF Preprints',
         'Cognitive Sciences ePrint Archive': 'Cogprints',
         OSF: 'OSF Preprints',
         'Research Papers in Economics': 'RePEc',


### PR DESCRIPTION
## Purpose
Fix isssue where selecting OSF Preprints filtered the preprints by `?provider=OSF Preprints` and
Share does not know what `OSF Preprints` is. So we keep it `OSF`.

## Summary of Changes/Side Effects


## Testing Notes

On the discover page, on the left pane, select OSF Preprints and make sure you see the filtered results (just OSF Preprints). and URL is `https://staging2.osf.io/preprints/discover?provider=OSF` not `https://staging2.osf.io/preprints/discover?provider=OSF Preprints`

## Ticket

[IN-353](https://openscience.atlassian.net/browse/IN-353)

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
