### PR TITLE
[IN-131][Preprints] Break-word correctly in licenseText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - preprint service select carousel redraw
 - correctly show parent projects in the "Choose project" dropdown
+- word break in license text
 
 ### Removed
 - logic related to updating the node's license

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - add `isWithdrawn` to google anlaytics pageTracking
 
+### Fixed
+- word break in license text
+
 ## [0.121.0] - 2018-08-16
 ### Added
 - whitelist functionality for discover page
@@ -24,7 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - preprint service select carousel redraw
 - correctly show parent projects in the "Choose project" dropdown
-- word break in license text
 
 ### Removed
 - logic related to updating the node's license

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -328,6 +328,20 @@ $logo-dir: 'img/provider_logos/';
             min-height: 100px;
         }
     }
+    .license-text {
+        pre {
+            white-space: pre-wrap;
+            font-size: 75%;
+            border:none;
+            width:100%;
+            text-align:justify;
+            max-height: 300px;
+            word-break: break-word;
+        }
+        span {
+            cursor: pointer;
+        }
+    }
 }
 
 /* Moderation */

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -129,10 +129,10 @@
                     {{/if}}
 
                     {{#if model.license.name}}
-                        <div class="p-t-xs">
+                        <div class="p-t-xs license-text">
                             <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
                             {{model.license.name}}
-                            <span style='cursor: pointer'>
+                            <span>
                                 {{#if showLicenseText }}
                                     {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
                                 {{else}}
@@ -140,7 +140,7 @@
                                 {{/if}}
                             </span>
                             {{#if showLicenseText}}
-                                <pre style='white-space: pre-wrap; font-size:75%; border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
+                                <pre>{{fullLicenseText}}</pre>
                             {{/if}}
                         </div>
                     {{/if}}


### PR DESCRIPTION
## Purpose
Wrap preprint license text on spaces instead of in the middle of the word.

## Summary of Changes/Side Effects
* Use `break-word`
* Use CSS classes


## Testing Notes
Make sure licenses look correct.


## Ticket
[[IN-131]](https://openscience.atlassian.net/browse/IN-131)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`