### PR TITLE
[IN-128][Preprints] Remove branded footer line-height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - word break in license text
 
+### Removed
+- branded footer line-height
+
 ## [0.121.0] - 2018-08-16
 ### Added
 - whitelist functionality for discover page
@@ -30,7 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - logic related to updating the node's license
-- branded footer line-height
 
 ## [0.120.2] - 2018-08-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - logic related to updating the node's license
+- branded footer line-height
 
 ## [0.120.2] - 2018-08-03
 ### Fixed

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1385,7 +1385,6 @@ nav.branded-navbar {
 
 .branded-footer-links {
     margin-bottom: 1em;
-    line-height: 28px;
 
     div {
         display: inline-block;


### PR DESCRIPTION
## Purpose
From ticket
>Reduce line height on footer text when wrapping. It doesn't look like the text is all one thing if the space between the wrapped text is the same as the space between the other lines.


## Summary of Changes/Side Effects
* Remove `line-height`

### Before:
<img width="775" alt="lh-before" src="https://user-images.githubusercontent.com/5659262/44104797-c12430b6-9fbd-11e8-9f8d-37c8a3ce9c01.png">

### After:
<img width="775" alt="lh-after" src="https://user-images.githubusercontent.com/5659262/44104803-c61e007e-9fbd-11e8-9375-567e7543cdc7.png">

## Testing Notes
Should only affect footer, make sure it looks right on small screens

## Ticket
[[IN-128]](https://openscience.atlassian.net/browse/IN-128)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
