### PR TITLE
[IN-363][Preprints] Allow downloading previous versions of preprints and/or suppl. files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - add `isWithdrawn` to google anlaytics pageTracking
+- ability to download previous preprint (primary file) versions
 - contributor query using elastic endpoint
 
 ### Fixed

--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import Component from '@ember/component';
-import { computed, observer } from '@ember/object';
+import { task } from 'ember-concurrency';
+import DS from 'ember-data';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import loadAll from 'ember-osf/utils/load-relationship';
 import Analytics from 'ember-osf/mixins/analytics';
@@ -25,101 +28,86 @@ import fileDownloadPath from '../utils/file-download-path';
  * ```
  * @class supplementary-file-browser
  */
+
+const { A } = Ember;
+const { PromiseArray } = DS;
+
 export default Component.extend(Analytics, {
     theme: service(),
 
     elementId: 'preprint-file-view',
-    endIndex: 6,
-    startIndex: 0,
-
+    maxFilesDisplayed: 6, // Max number of files displayed in suppl. files carousel
     scrollAnim: '',
     selectedFile: null,
     allowCommenting: false,
 
-    hasAdditionalFiles: computed('files', function() {
-        return this.get('files.length') > 1;
+    hasAdditionalFiles: computed.gt('files.length', 1),
+    hasPrev: computed.gt('startIndex', 0),
+    selectedFileIsPrimaryFile: computed.equal('selectedIndex', 0),
+
+    primaryFileHasVersions: computed('selectedFileIsPrimaryFile', 'versions', function() {
+        const versions = this.get('versions');
+        if (!versions) return;
+
+        return this.get('selectedFileIsPrimaryFile') && versions.length > 1;
     }),
 
-    hasPrev: computed('files', 'endIndex', 'startIndex', function() {
-        return this.get('startIndex') > 0;
+    startIndex: computed('selectedIndex', 'maxFilesDisplayed', function() {
+        const selectedIndex = this.get('selectedIndex') || 0;
+        const maxFilesDisplayed = this.get('maxFilesDisplayed');
+
+        return Math.floor(selectedIndex / maxFilesDisplayed) * maxFilesDisplayed;
     }),
 
-    hasNext: computed('files', 'endIndex', 'startIndex', function() {
+    endIndex: computed('selectedIndex', 'maxFilesDisplayed', function() {
+        const maxFilesDisplayed = this.get('maxFilesDisplayed');
+        const selectedIndex = this.get('selectedIndex') || maxFilesDisplayed;
+
+        return Math.ceil(selectedIndex / maxFilesDisplayed) * maxFilesDisplayed;
+    }),
+
+    hasNext: computed('files.length', 'endIndex', function() {
         return this.get('endIndex') < this.get('files.length');
     }),
 
+    versions: computed('selectedFile', function() {
+        const selectedFile = this.get('selectedFile');
 
-    selectedFileChanged: computed('selectedFile', function() {
-        const eventData = {
-            file_views: {
-                preprint: {
-                    type: 'preprint',
-                    id: this.get('preprint.id'),
-                },
-                file: {
-                    id: this.get('selectedFile.id'),
-                    primaryFile: this.get('preprint.primaryFile.id') === this.get('selectedFile.id'),
-                    version: this.get('selectedFile.currentVersion'),
-                },
-            },
-        };
-        this.get('metrics').invoke('trackSpecificCollection', 'Keen', {
-            collection: 'preprint-file-views',
-            eventData,
-            node: this.get('node'),
+        if (!selectedFile || !this.get('selectedFileIsPrimaryFile')) {
+            return A();
+        }
+
+        const versions = A();
+
+        return PromiseArray.create({
+            promise: loadAll(selectedFile, 'versions', versions, { sort: '-id', 'page[size]': 50 })
+                .then(this.__serializeVersions.bind(this, versions)),
         });
     }),
-    fileDownloadURL: computed('selectedFile', function() {
-        return fileDownloadPath(this.get('selectedFile'), this.get('node'));
-    }),
-    _chosenFile: observer('chosenFile', 'indexes', function() { /* eslint-disable-line ember/no-observers */
-        const fid = this.get('chosenFile');
-        const index = this.get('indexes') && this.get('indexes').indexOf(fid);
-        if (fid && index !== -1) {
-            this.set('selectedFile', this.get('files')[index]);
-        }
-    }),
-    _moveIfNeeded: observer('selectedFile', function() { /* eslint-disable-line ember/no-observers */
-        const index = this.get('files') && this.get('files').indexOf(this.get('selectedFile'));
-        if (index < 0) {
-            return;
-        }
-        if (index >= this.get('endIndex') || index < this.get('startIndex')) {
-            const max = this.get('files').length - 6;
-            if (index > max) {
-                this.set('startIndex', max);
-                this.set('endIndex', this.get('files').length);
-            } else {
-                this.set('startIndex', index);
-                this.set('endIndex', index + 6);
-            }
-        }
+
+    fileRendererURL: computed('selectedFile.links.download', 'selectedVersion', function() {
+        const downloadUrl = this.get('selectedFile.links.download');
+        const selectedVersion = this.get('selectedVersion');
+
+        return (downloadUrl && selectedVersion) ? `${downloadUrl}?version=${selectedVersion}` : null;
     }),
 
-    // This needs to be changed away from an observer, but "preprint" changes
-    // frequently enough that it is really complicated
-    __files: observer('preprint', function() { /* eslint-disable-line ember/no-observers */
-        this.set('files', []);
-        this.set('selectedFile', null);
-        /* eslint-disable ember/named-functions-in-promises */
-        this.get('node').get('files')
-            .then((fileProviders) => {
-                this.set('fileProvider', fileProviders.findBy('name', 'osfstorage'));
-                return loadAll(this.get('fileProvider'), 'files', this.get('files'), { 'page[size]': 50 });
-            })
-            .then(() => this.get('preprint').get('primaryFile'))
-            .then((pf) => {
-                this.get('files').removeObject(pf);
-                this.set('primaryFile', pf);
-                this.set('selectedFile', this.get('primaryFile'));
-                this.set('files', [this.get('primaryFile')].concat(this.get('files')));
-                this.set('indexes', this.get('files').map(each => each.id));
-            });
-        /* eslint-enable ember/named-functions-in-promises */
+    fileDownloadURL: computed('selectedFile', 'selectedVersion', function() {
+        return fileDownloadPath(this.get('selectedFile'), this.get('node'));
     }),
+
+    updateFiles: computed('preprint', function() {
+        this.get('getFiles').perform();
+    }),
+
     init() {
         this._super(...arguments);
-        this.__files();
+        this.setProperties({
+            files: A(),
+            selectedFile: null,
+            selectedIndex: null,
+        });
+        this.get('getFiles').perform();
     },
 
     didReceiveAttrs() {
@@ -135,11 +123,19 @@ export default Component.extend(Analytics, {
                     label: 'Content - Next',
                 });
 
-            if (this.get('endIndex') > this.get('files.length')) return;
+            const endIndex = this.get('endIndex');
 
-            this.set('scrollAnim', `to${direction}`);
-            this.set('endIndex', this.get('endIndex') + 5);
-            this.set('startIndex', this.get('startIndex') + 5);
+            if (endIndex > this.get('files.length')) {
+                return;
+            }
+
+            const maxFilesDisplayed = this.get('maxFilesDisplayed');
+
+            this.setProperties({
+                scrollAnim: `to${direction}`,
+                startIndex: this.get('startIndex') + maxFilesDisplayed,
+                endIndex: endIndex + maxFilesDisplayed,
+            });
         },
         prev(direction) {
             this.get('metrics')
@@ -148,19 +144,22 @@ export default Component.extend(Analytics, {
                     action: 'click',
                     label: 'Content - Prev',
                 });
-            const start = this.get('startIndex');
-            if (start <= 0) return;
 
-            this.set('scrollAnim', `to${direction}`);
-            if ((start - 5) < 0) {
-                this.set('startIndex', 0);
-                this.set('endIndex', 6);
-            } else {
-                this.set('startIndex', start - 5);
-                this.set('endIndex', this.get('endIndex') - 5);
+            const startIndex = this.get('startIndex');
+
+            if (startIndex <= 0) {
+                return;
             }
+
+            const maxFilesDisplayed = this.get('maxFilesDisplayed');
+
+            this.setProperties({
+                scrollAnim: `to${direction}`,
+                startIndex: Math.max(startIndex - maxFilesDisplayed, 0),
+                endIndex: Math.max(this.get('endIndex') - maxFilesDisplayed, maxFilesDisplayed),
+            });
         },
-        changeFile(file) {
+        changeFile(selectedFile, selectedIndex) {
             this.get('metrics')
                 .trackEvent({
                     category: 'file browser',
@@ -168,9 +167,13 @@ export default Component.extend(Analytics, {
                     label: 'Content - File',
                 });
 
-            this.set('selectedFile', file);
+            this.setProperties({
+                selectedFile,
+                selectedIndex,
+            });
+
             if (this.chooseFile) {
-                this.chooseFile(file);
+                this.chooseFile(selectedFile);
             }
         },
     },
@@ -179,4 +182,48 @@ export default Component.extend(Analytics, {
         const publishedAndPublic = this.get('preprint.isPublished') && this.get('node.public');
         this.set('allowCommenting', provider.get('allowCommenting') && publishedAndPublic);
     },
+    __serializeVersions(versions) {
+        const downloadUrl = this.get('selectedFile.links.download');
+        const filename = this.get('selectedFile.name');
+
+        if (this.get('selectedFileIsPrimaryFile')) {
+            this.set('primaryFileHasVersions', versions.length > 1);
+        }
+
+        return versions
+            .map((version) => {
+                const dateFormatted = encodeURIComponent(version.get('dateCreated').toISOString());
+                const displayName = filename.replace(/(\.\w+)?$/, ext => `-${dateFormatted}${ext}`);
+                version.set('downloadUrl', `${downloadUrl}?version=${version.id}&displayName=${displayName}`);
+                return version;
+            });
+    },
+    __initProperties(primaryFile) {
+        const files = this.get('files');
+
+        files.removeObject(primaryFile);
+        files.unshiftObject(primaryFile);
+
+        const selectedFile = files.find(({ id }) => id === this.get('chosenFile')) || primaryFile;
+
+        this.setProperties({
+            primaryFile,
+            selectedFile,
+            files,
+            selectedIndex: files.indexOf(selectedFile),
+        });
+    },
+    getFiles: task(function* () {
+        const providers = yield this.get('node.files');
+        yield loadAll(
+            providers.findBy('name', 'osfstorage'),
+            'files',
+            this.get('files'),
+            {
+                'page[size]': 50,
+            },
+        );
+        const primaryFile = yield this.get('preprint.primaryFile');
+        this.__initProperties(primaryFile);
+    }),
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -432,6 +432,7 @@ export default {
         },
         'supplementary-file-browser': {
             primary: 'Primary',
+            download_previous_versions: 'Download previous versions',
         },
         'taxonomy-top-list': {
             // Nothing to translate

--- a/app/locales/es-disabled/translations.js
+++ b/app/locales/es-disabled/translations.js
@@ -364,6 +364,7 @@ export default {
         },
         'supplementary-file-browser': {
             primary: 'Primario',
+            download_previous_versions: 'Descargar versiones anteriores',
         },
         'permission-language': {
             arxivTrademarkLicense,

--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -5,3 +5,5 @@ $preprint-title-hover: #D5E6ED;
 $gradient-percentage: 15%;
 $nav-bar-height: 25px;
 $carousel-control-width: 10%;
+$color-bg-default: #f8f8f8;
+$color-border-gray-light: #d9d9d9;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1025,6 +1025,32 @@ hr {
         background: #D8D8D8;
         font-size: 2em;
     }
+
+    .file-versions-dropdown-menu {
+        background-color: $color-bg-default;
+
+        a {
+            color: inherit;
+            display: flex;
+            justify-content: space-between;
+            background: transparent;
+            width: 100%;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        li a:hover {
+            background-color: $color-border-gray-light;
+            text-decoration: none;
+        }
+    }
+
+    .scrollable-menu {
+        height: auto;
+        max-height: 200px;
+        overflow-x: hidden;
+    }
+
 }
 
 .file-browser {
@@ -1247,12 +1273,33 @@ label.title-label {
     text-align: right;
 }
 
+.current-version {
+    text-align: right;
+}
+
+/* Remove gutters between bootstrap cols */
+.row.no-gutters {
+    margin-right: 0;
+    margin-left: 0;
+}
+
+.row.no-gutters > [class^="col-"],
+.row.no-gutters > [class*=" col-"] {
+    padding-right: 0;
+    padding-left: 0;
+}
+
+@media (max-width: 1199.98px) {
+
+      .supplemental-downloads {
+          float: none !important;
+          text-align: inherit !important;
+      }
+}
+
 @media (max-width: 768px) {
     .edit-button-and-logo {
         padding-top: 20px;
-    }
-    .supplemental-downloads {
-        float: none !important;
     }
     .preprint-image {
         margin-top: 0 !important;

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -5,45 +5,68 @@
     height="700"}}
 {{/file-renderer}}
 
-<div class="row">
-    <div class="col-sm-6">
-        <p class="f-w-lg p-b-md">{{selectedFile.name}}</p>
+<div class="row no-gutters">
+    <div class="col-lg-4">
+        <p id="selectedFileName" class="f-w-lg p-b-md">{{selectedFile.name}}</p>
     </div>
-    <div class="col-sm-6 text-nowrap supplemental-downloads">
-        {{#if (eq selectedFile.id preprint.primaryFile.id)}}
-            <a class="btn btn-default btn-sm" href={{fileDownloadURL}} onclick={{action dualTrackNonContributors 'link' 'Content - Download' selectedFile.links.download true}}> {{t "content.share.download_preprint" documentType=provider.documentType}}</a>
+    <div class="col-lg-2 hidden-lg">
+        <p class="p-b-md">{{t "content.version"}}: {{selectedFile.currentVersion}}</p>
+    </div>
+    <div class="clearfix visible-xs-block"></div>
+    <div class="col-lg-6 col-xs-12 text-nowrap supplemental-downloads">
+        {{#if (and selectedFileIsPrimaryFile primaryFileHasVersions)}}
+            {{#bs-dropdown classNames="lock-span" as |dd|}}
+                {{#dd.toggle classNames="btn btn-default btn-sm dropdown-button"}}
+                    {{t 'components.supplementary-file-browser.download_previous_versions'}}
+                    <span class="fa fa-caret-down"></span>
+                {{/dd.toggle}}
+                {{#dd.menu class='file-versions-dropdown-menu scrollable-menu' as |menu|}}
+                    {{#each versions as |version|}}
+                        {{#menu.item}}
+                            <a class="dropdown-item" href="{{version.downloadUrl}}" onclick={{action 'click' 'link' 'Content - Download Previous Version'}}>
+                                {{t "content.version"}} {{version.id}}, {{moment-format version.dateCreated "MM/DD/YYYY HH:mm:SS"}}
+                            </a>
+                        {{/menu.item}}
+                    {{/each}}
+                {{/dd.menu}}
+            {{/bs-dropdown}}
+        {{/if}}
+        {{#if selectedFileIsPrimaryFile}}
+            <a id="primaryFileDownloadUrl" class="btn btn-default btn-sm" href={{fileDownloadURL}} onclick={{action dualTrackNonContributors 'link' 'Content - Download' selectedFile.links.download true}}> {{t "content.share.download_preprint" documentType=provider.documentType}}</a>
         {{else}}
             <a class="btn btn-default btn-sm" href={{fileDownloadURL}} onclick={{action dualTrackNonContributors 'link' 'Content - Download Supplementary File' selectedFile.links.download false}}> {{t "content.share.download_file"}} </a>
         {{/if}}
-        <span class="p-sm"> {{t "content.version"}}: {{selectedFile.currentVersion}}</span>
+    </div>
+    <div class="col-lg-2 visible-lg current-version">
+        <span id="currentVersion" class="p-sm">{{t "content.version"}}: {{selectedFile.currentVersion}}</span>
     </div>
 </div>
 
 {{#if hasAdditionalFiles}}
     <section class="osf-box p-md m-t-sm m-b-lg">
         {{#liquid-bind (slice-array files startIndex endIndex) use=scrollAnim as |list|}}
-            {{#each list as |supplement|}}
-                {{#if (eq supplement.kind "folder")}}
-                    <a href={{concat node.links.html 'files'}} target="_blank" rel="noopener" class="hint--bottom col-xs-2 p-md box m-b-xl hidden-xs" aria-label={{supplement.name}}>
+            {{#each list as |item index|}}
+                {{#if (eq item.kind "folder")}}
+                    <a href={{concat node.links.html 'files'}} target="_blank" rel="noopener" class="hint--bottom col-xs-2 p-md box m-b-xl hidden-xs" aria-label={{item.name}}>
                         <i class="fa fa-folder fa-2x p-b-xs" aria-hidden="true"></i>
                     </a>
                     <a href={{preprint.links.html}} class="visible-xs truncate">
-                        <i class="fa fa-folder p-b-xs p-r-sm"></i> {{supplement.name}}
+                        <i class="fa fa-folder p-b-xs p-r-sm"></i> {{item.name}}
                     </a>
                 {{else}}
-                    <label class="hint--bottom col-xs-2 p-md box m-b-xl hidden-xs {{if (eq selectedFile supplement) 'selected'}}" aria-label={{supplement.name}} {{action 'changeFile' supplement}}>
-                        {{#if (eq selectedFile supplement)}}
+                    <label class="hint--bottom col-xs-2 p-md box m-b-xl hidden-xs {{if (eq selectedFile item) 'selected'}}" aria-label={{item.name}} {{action 'changeFile' item index}}>
+                        {{#if (eq selectedFile item)}}
                             <b class="file-selected-arrow">&#9660;</b>
                         {{/if}}
-                        {{#if (eq preprint.primaryFile.id supplement.id)}}
+                        {{#if (eq preprint.primaryFile.id item.id)}}
                             <i style="margin-top: -4px;" class="fa fa-file-text fa-2x p-b-xs preprint-image" aria-hidden="true"></i>
                             <p class="hidden-xs" style="font-size: 75%; margin-bottom: -10px">{{t "components.supplementary-file-browser.primary"}}</p>
                         {{else}}
                             <i style="color:gray" class="fa fa-file-text fa-2x p-b-xs" aria-hidden="true"></i>
                         {{/if}}
                     </label>
-                    <a href={{preprint.links.html}} style="color:gray;" class="{{if (eq preprint.primaryFile.id supplement.id) 'preprint-file-link'}} {{if (eq selectedFile supplement) 'selected'}} visible-xs truncate" {{action 'changeFile' supplement}}>
-                        <i class="fa fa-file-text p-b-xs p-r-sm"></i> {{supplement.name}}
+                    <a href={{preprint.links.html}} style="color:gray;" class="{{if (eq preprint.primaryFile.id item.id) 'preprint-file-link'}} {{if (eq selectedFile item) 'selected'}} visible-xs truncate" {{action 'changeFile' item index}}>
+                        <i class="fa fa-file-text p-b-xs p-r-sm"></i> {{item.name}}
                     </a>
                 {{/if}}
             {{/each}}

--- a/app/utils/file-download-path.js
+++ b/app/utils/file-download-path.js
@@ -1,11 +1,11 @@
 import config from 'ember-get-config';
 
-export default function fileDownloadPath(file, node) {
-    if (!file || !node) {
+export default function fileDownloadPath(file, node, version) {
+    if (!(file && node)) {
         return;
     }
-    if (file.get('guid')) {
-        return `${config.OSF.url}${file.get('guid')}/?action=download`;
-    }
-    return `${config.OSF.url}project/${node.get('id')}/files/osfstorage${file.get('path')}/?action=download`;
+    const guid = file.get('guid');
+    const path = guid ? `${guid}/download/?` : `project/${node.get('id')}/files/osfstorage${file.get('path')}/?action=download&`;
+
+    return `${config.OSF.url}${path}${version ? `version=${version}` : ''}`.replace(/[&?]$/, '');
 }

--- a/package.json
+++ b/package.json
@@ -107,5 +107,6 @@
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-osf-preprints/issues"
   },
-  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme"
+  "homepage": "https://github.com/CenterForOpenScience/ember-osf-preprints#readme",
+  "dependencies": {}
 }

--- a/tests/integration/components/supplementary-file-browser-test.js
+++ b/tests/integration/components/supplementary-file-browser-test.js
@@ -1,6 +1,7 @@
 import { A } from '@ember/array';
 import RSVP, { resolve } from 'rsvp';
 import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
 import Service from '@ember/service';
 import ArrayProxy from '@ember/array/proxy';
 import hbs from 'htmlbars-inline-precompile';
@@ -18,14 +19,32 @@ const themeStub = Service.extend({
 moduleForComponent('supplementary-file-browser', 'Integration | Component | supplementary file browser', {
     integration: true,
     beforeEach() {
-        const providerFiles = () => resolve(ArrayProxy.create({
-            content: A([{ name: 'test folder', kind: 'folder' }, { name: 'chosenFile', kind: 'file' }]),
+        const fileVersions = () => resolve(ArrayProxy.create({
+            content: A([
+                EmberObject.create({ size: 4, dateCreated: new Date('05 October 2011 14:48 UTC') }),
+                EmberObject.create({ size: 5, dateCreated: new Date('05 October 2011 14:49 UTC') }),
+            ]),
             meta: {
                 pagination: {
                     total: 1,
                 },
             },
         }));
+
+        const providerFiles = () => resolve(ArrayProxy.create({
+            content: A([
+                EmberObject.create({
+                    id: 345, name: 'test folder', kind: 'folder',
+                }),
+                EmberObject.create({ id: 350, name: 'chosenFile', kind: 'file' }),
+            ]),
+            meta: {
+                pagination: {
+                    total: 3,
+                },
+            },
+        }));
+
         const providersQuery = resolve(A([{
             name: 'osfstorage',
             queryHasMany: providerFiles,
@@ -41,7 +60,10 @@ moduleForComponent('supplementary-file-browser', 'Integration | Component | supp
             name: 'test file',
             currentVersion: '1.12',
             id: 890,
+            queryHasMany: fileVersions,
+            links: { download: '/link/to/download/url' },
         });
+
         const preprint = EmberObject.create({
             primaryFile: file,
             node,
@@ -49,6 +71,7 @@ moduleForComponent('supplementary-file-browser', 'Integration | Component | supp
             files: providersQuery,
             id: 890,
         });
+
         const dualTrackNonContributors = () => {};
 
         this.register('service:theme', themeStub);
@@ -73,12 +96,14 @@ test('it renders', function(assert) {
     this.render(hbs`{{supplementary-file-browser
         preprint=preprint
         node=node
-        hasAdditionalFiles=false    
+        hasAdditionalFiles=false
         dualTrackNonContributors=(action dualTrackNonContributors)
     }}`);
-    assert.equal(this.$('.osf-box').length, 0);
-    assert.equal(this.$('.row p').text(), 'test file');
-    assert.equal(this.$('.supplemental-downloads span').text(), ' Version: 1.12');
+    return wait().then(() => {
+        assert.equal(this.$('.osf-box').length, 0);
+        assert.equal(this.$('#selectedFileName').text(), 'test file');
+        assert.equal(this.$('#currentVersion').text(), 'Version: 1.12');
+    });
 });
 
 test('has additional files', function(assert) {
@@ -99,15 +124,19 @@ test('has additional files', function(assert) {
     assert.equal(this.$('#downArrow').length, 1);
 
     // Checks for different file types to render differently
-    assert.ok(this.$('i.fa-folder').length);
-    assert.ok(this.$('i.preprint-image').length);
-    assert.ok(this.$('i.fa-file-text').length);
+    return wait().then(() => {
+        assert.ok(this.$('i.fa-folder').length);
+        assert.ok(this.$('i.preprint-image').length);
+        assert.ok(this.$('i.fa-file-text').length);
+    });
 });
 
 test('fileDownloadURL computed property', function (assert) {
     render(this);
 
-    const url = this.$('.supplemental-downloads > a').attr('href');
-    assert.ok(url);
-    assert.ok(url.indexOf(this.get('primaryFile.guid')) !== -1, 'Url does not have file\'s guid in it');
+    return wait().then(() => {
+        const url = this.$('#primaryFileDownloadUrl').attr('href');
+        assert.ok(url);
+        assert.ok(url.indexOf(this.get('primaryFile.guid')) !== -1, 'Url does not have file\'s guid in it');
+    });
 });

--- a/tests/unit/utils/file-download-path-test.js
+++ b/tests/unit/utils/file-download-path-test.js
@@ -1,10 +1,55 @@
 import fileDownloadPath from 'preprint-service/utils/file-download-path';
 import { module, test } from 'qunit';
+import config from 'ember-get-config';
+import Ember from 'ember';
 
 module('Unit | Utility | file download path');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
+const osfUrl = config.OSF.url;
+
+test('No arguments should return undefined', function(assert) {
     const result = fileDownloadPath();
     assert.ok(typeof result === 'undefined');
+});
+test('with file guid', function(assert) {
+    const file = Ember.Object.create({
+        guid: 'abc12',
+        path: 'blah',
+    });
+    const node = Ember.Object.create({
+        id: 'def34',
+    });
+    const result = fileDownloadPath(file, node);
+    assert.strictEqual(result, `${osfUrl}abc12/download/`);
+});
+test('without file guid', function(assert) {
+    const file = Ember.Object.create({
+        path: '/blah',
+    });
+    const node = Ember.Object.create({
+        id: 'def34',
+    });
+    const result = fileDownloadPath(file, node);
+    assert.strictEqual(result, `${osfUrl}project/def34/files/osfstorage/blah/?action=download`);
+});
+test('file guid with version', function(assert) {
+    const file = Ember.Object.create({
+        guid: 'abc12',
+        path: '/blah',
+    });
+    const node = Ember.Object.create({
+        id: 'def34',
+    });
+    const result = fileDownloadPath(file, node, 4);
+    assert.strictEqual(result, `${osfUrl}abc12/download/?version=4`);
+});
+test('without file guid', function(assert) {
+    const file = Ember.Object.create({
+        path: '/blah',
+    });
+    const node = Ember.Object.create({
+        id: 'def34',
+    });
+    const result = fileDownloadPath(file, node, 7);
+    assert.strictEqual(result, `${osfUrl}project/def34/files/osfstorage/blah/?action=download&version=7`);
 });


### PR DESCRIPTION
## Purpose

Based on @binoculars PR https://github.com/CenterForOpenScience/ember-osf-preprints/pull/285
Allow versions of preprint or suppl. files to be downloaded from the preprint detail page.
ht @binoculars 

## Summary of Changes/Side Effects

- Updated `supplementary-file-browser` to support downloading file versions
- Updated/fixed and added tests 

## Testing Notes
....coming soon after demo.

## Ticket

>>> [IN-363 ](https://openscience.atlassian.net/browse/IN-363)

## After

http://recordit.co/uDykCHmWSo
**latest: ** http://recordit.co/UZ0S0MYly0

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`