### PR TITLE
[Preprint Withdrawals][Preprints][EMB-550][EMB-549] Add contributor withdrawal of preprints; Preprint tombstone page.

### DIFF
--- a/app/components/preprint-status-banner/component.js
+++ b/app/components/preprint-status-banner/component.js
@@ -6,6 +6,8 @@ import { alias } from '@ember/object/computed';
 const PENDING = 'pending';
 const ACCEPTED = 'accepted';
 const REJECTED = 'rejected';
+const PENDING_WITHDRAWAL = 'pendingWithdrawal';
+const WITHDRAWN = 'withdrawn';
 
 const PRE_MODERATION = 'pre-moderation';
 const POST_MODERATION = 'post-moderation';
@@ -14,12 +16,15 @@ const ICONS = {
     [PENDING]: 'fa-hourglass-o',
     [ACCEPTED]: 'fa-check-circle-o',
     [REJECTED]: 'fa-times-circle-o',
+    [PENDING_WITHDRAWAL]: 'fa-hourglass-o',
+    [WITHDRAWN]: 'fa-exclamation-triangle',
 };
 
 const STATUS = {
     [PENDING]: 'components.preprint-status-banner.pending',
     [ACCEPTED]: 'components.preprint-status-banner.accepted',
     [REJECTED]: 'components.preprint-status-banner.rejected',
+    [PENDING_WITHDRAWAL]: 'components.preprint-status-banner.pending_withdrawal',
 };
 
 const MESSAGE = {
@@ -27,6 +32,8 @@ const MESSAGE = {
     [POST_MODERATION]: 'components.preprint-status-banner.message.pending_post',
     [ACCEPTED]: 'components.preprint-status-banner.message.accepted',
     [REJECTED]: 'components.preprint-status-banner.message.rejected',
+    [PENDING_WITHDRAWAL]: 'components.preprint-status-banner.message.pending_withdrawal',
+    [WITHDRAWN]: 'components.preprint-status-banner.message.withdrawn',
 };
 
 const WORKFLOW = {
@@ -39,11 +46,15 @@ const CLASS_NAMES = {
     [POST_MODERATION]: 'preprint-status-pending-post',
     [ACCEPTED]: 'preprint-status-accepted',
     [REJECTED]: 'preprint-status-rejected',
+    [PENDING_WITHDRAWAL]: 'preprint-status-rejected',
+    [WITHDRAWN]: 'preprint-status-withdrawn',
 };
 
 export default Component.extend({
     i18n: service(),
     theme: service(),
+
+    isWithdrawn: false,
 
     // translations
     labelModeratorFeedback: 'components.preprint-status-banner.feedback.moderator_feedback',
@@ -59,35 +70,57 @@ export default Component.extend({
     reviewerComment: alias('latestAction.comment'),
     reviewerName: alias('latestAction.creator.fullName'),
 
-    getClassName: computed('submission.{provider.reviewsWorkflow,reviewsState}', function() {
-        return this.get('submission.reviewsState') === PENDING ?
-            CLASS_NAMES[this.get('submission.provider.reviewsWorkflow')] :
-            CLASS_NAMES[this.get('submission.reviewsState')];
+    getClassName: computed('submission.{provider.reviewsWorkflow,reviewsState}', 'isPendingWithdrawal', 'isWithdrawn', function() {
+        if (this.get('isPendingWithdrawal')) {
+            return CLASS_NAMES[PENDING_WITHDRAWAL];
+        } else if (this.get('isWithdrawn')) {
+            return CLASS_NAMES[WITHDRAWN];
+        } else {
+            return this.get('submission.reviewsState') === PENDING ?
+                CLASS_NAMES[this.get('submission.provider.reviewsWorkflow')] :
+                CLASS_NAMES[this.get('submission.reviewsState')];
+        }
     }),
 
-    bannerContent: computed('statusExplanation', 'workflow', 'theme.{isProvider,provider.name}', function() {
+    bannerContent: computed('statusExplanation', 'workflow', 'theme.{isProvider,provider.name}', 'isPendingWithdrawal', 'isWithdrawn', function() {
         const i18n = this.get('i18n');
-        const tName = this.get('theme.isProvider') ?
-            this.get('theme.provider.name') :
-            i18n.t('global.brand_name');
-
-        const tWorkflow = i18n.t(this.get('workflow'));
-        const tStatusExplanation = i18n.t(this.get('statusExplanation'));
-        return `${i18n.t(this.get('baseMessage'), { name: tName, reviewsWorkflow: tWorkflow, documentType: this.get('submission.provider.documentType') })} ${tStatusExplanation}.`;
+        if (this.get('isPendingWithdrawal')) {
+            return i18n.t(this.get('statusExplanation'), { documentType: this.get('submission.provider.documentType') });
+        } else if (this.get('isWithdrawn')) {
+            return i18n.t(MESSAGE[WITHDRAWN], { documentType: this.get('submission.provider.documentType') });
+        } else {
+            const tName = this.get('theme.isProvider') ?
+                this.get('theme.provider.name') :
+                i18n.t('global.brand_name');
+            const tWorkflow = i18n.t(this.get('workflow'));
+            const tStatusExplanation = i18n.t(this.get('statusExplanation'));
+            return `${i18n.t(this.get('baseMessage'), { name: tName, reviewsWorkflow: tWorkflow, documentType: this.get('submission.provider.documentType') })} ${tStatusExplanation}.`;
+        }
     }),
 
-    statusExplanation: computed('submission.{provider.reviewsWorkflow,reviewsState}', function() {
-        return this.get('submission.reviewsState') === PENDING ?
-            MESSAGE[this.get('submission.provider.reviewsWorkflow')] :
-            MESSAGE[this.get('submission.reviewsState')];
+    statusExplanation: computed('submission.{provider.reviewsWorkflow,reviewsState}', 'isPendingWithdrawal', function() {
+        if (this.get('isPendingWithdrawal')) {
+            return MESSAGE[PENDING_WITHDRAWAL];
+        } else {
+            return this.get('submission.reviewsState') === PENDING ?
+                MESSAGE[this.get('submission.provider.reviewsWorkflow')] :
+                MESSAGE[this.get('submission.reviewsState')];
+        }
     }),
 
-    status: computed('submission.reviewsState', function() {
-        return STATUS[this.get('submission.reviewsState')];
+    status: computed('submission.reviewsState', 'isPendingWithdrawal', function() {
+        const currentState = this.get('isPendingWithdrawal') ? PENDING_WITHDRAWAL : this.get('submission.reviewsState');
+        return STATUS[currentState];
     }),
 
-    icon: computed('submission.reviewsState', function() {
-        return ICONS[this.get('submission.reviewsState')];
+    icon: computed('submission.reviewsState', 'isPendingWithdrawal', 'isWithdrawn', function() {
+        let currentState = this.get('submission.reviewsState');
+        if (this.get('isPendingWithdrawal')) {
+            currentState = PENDING_WITHDRAWAL;
+        } else if (this.get('isWithdrawn')) {
+            currentState = WITHDRAWN;
+        }
+        return ICONS[currentState];
     }),
 
     workflow: computed('submission.provider.reviewsWorkflow', function () {

--- a/app/components/preprint-status-banner/template.hbs
+++ b/app/components/preprint-status-banner/template.hbs
@@ -3,37 +3,44 @@
         {{#if submission.provider.isPending}}
             Loading...
         {{else}}
-            <div class="status-explanation">
-                <i class="fa {{icon}} status-icon" aria-hidden="true"></i>
-                <strong>{{t status}}:</strong>
-                <span>{{bannerContent}}</span>
-            </div>
-            {{#if (and reviewerComment (not submission.provider.reviewsCommentsPrivate))}}
-                <div class="dropdown reviewer-feedback">
-                    <button class="btn btn-default dropdown-toggle feedback-btn" type="button" data-toggle="dropdown">
-                        {{t labelModeratorFeedback}} <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    </button>
-                    <div class="dropdown-menu">
-                        <div class="feedback-header">
-                            <span id="moderator-feedback">{{t labelModeratorFeedback}}</span>
-                            <a role="button" aria-label="Close" href="#" class="dropdown-toggle" data-toggle="dropdown">
-                                <i class="fa fa-times"></i>
-                            </a>
-                        </div>
-                        <div class="status p-md">
-                            <strong>{{t status}}</strong>
-                            <div>{{t feedbackBaseMessage documentType=submission.provider.documentType}} {{t statusExplanation}}.</div>
-                        </div>
-                        <div class="moderator-comment" aria-labelledby="moderator-feedback">
-                            <p>{{reviewerComment}}</p>
-                            {{#if (not submission.provider.reviewsCommentsAnonymous)}}
-                                <div>{{reviewerName}}</div>
-                            {{/if}}
-                            {{if theme.isProvider theme.provider.name (t "global.brand_name")}} {{t moderator}}
-                        </div>
-                        <div class="feedback-footer p-md"></div>
-                    </div>
+            {{#if isWithdrawn}}
+                <div class="status-explanation">
+                    <i class="fa {{icon}} status-icon" aria-hidden="true"></i>
+                    <span style="padding-left: 5px">{{bannerContent}}</span>
                 </div>
+            {{else}}
+                <div class="status-explanation">
+                    <i class="fa {{icon}} status-icon" aria-hidden="true"></i>
+                    <strong>{{t status}}:</strong>
+                    <span>{{bannerContent}}</span>
+                </div>
+                {{#if (and reviewerComment (not submission.provider.reviewsCommentsPrivate))}}
+                    <div class="dropdown reviewer-feedback">
+                        <button class="btn btn-default dropdown-toggle feedback-btn" type="button" data-toggle="dropdown">
+                            {{t labelModeratorFeedback}} <i class="fa fa-caret-down" aria-hidden="true"></i>
+                        </button>
+                        <div class="dropdown-menu">
+                            <div class="feedback-header">
+                                <span id="moderator-feedback">{{t labelModeratorFeedback}}</span>
+                                <a role="button" aria-label="Close" href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                    <i class="fa fa-times"></i>
+                                </a>
+                            </div>
+                            <div class="status p-md">
+                                <strong>{{t status}}</strong>
+                                <div>{{t feedbackBaseMessage documentType=submission.provider.documentType}} {{t statusExplanation}}.</div>
+                            </div>
+                            <div class="moderator-comment" aria-labelledby="moderator-feedback">
+                                <p>{{reviewerComment}}</p>
+                                {{#if (not submission.provider.reviewsCommentsAnonymous)}}
+                                    <div>{{reviewerName}}</div>
+                                {{/if}}
+                                {{if theme.isProvider theme.provider.name (t "global.brand_name")}} {{t moderator}}
+                            </div>
+                            <div class="feedback-footer p-md"></div>
+                        </div>
+                    </div>
+                {{/if}}
             {{/if}}
         {{/if}}
     </div>

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -51,7 +51,10 @@ export default Controller.extend(Analytics, {
     showLicenseText: false,
     primaryFile: null,
     showModalClaimUser: false,
+    isPendingWithdrawal: false,
+    isWithdrawn: null,
     expandedAbstract: navigator.userAgent.includes('Prerender'),
+
     hasTag: computed.bool('model.tags.length'),
     relevantDate: computed.alias('model.dateCreated'),
     metricsExtra: computed('model', function() {
@@ -108,13 +111,13 @@ export default Controller.extend(Analytics, {
         return false;
     }),
 
-    showStatusBanner: computed('model.{public,provider.reviewsWorkflow,reviewsState}', 'userIsContrib', function() {
+    showStatusBanner: computed('model.{public,provider.reviewsWorkflow,reviewsState}', 'userIsContrib', 'isPendingWithdrawal', function() {
         return (
             this.get('model.provider.reviewsWorkflow')
             && this.get('model.public')
             && this.get('userIsContrib')
             && this.get('model.reviewsState') !== INITIAL
-        );
+        ) || this.get('isPendingWithdrawal');
     }),
 
     disciplineReduced: computed('model.subjects', function() {

--- a/app/controllers/content/withdraw.js
+++ b/app/controllers/content/withdraw.js
@@ -1,0 +1,66 @@
+import Controller from '@ember/controller';
+import { task } from 'ember-concurrency';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+const PRE_MODERATION = 'pre-moderation';
+const POST_MODERATION = 'post-moderation';
+const NO_MODERATION = 'no-moderation';
+
+const NOTICE_MESSAGE = {
+    [PRE_MODERATION]: 'withdraw.pre_moderation_notice',
+    [POST_MODERATION]: 'withdraw.post_moderation_notice',
+    [NO_MODERATION]: 'withdraw.no_moderation_notice',
+};
+
+export default Controller.extend({
+    theme: service(),
+    store: service(),
+    currentUser: service(),
+    toast: service(),
+    i18n: service(),
+    explanation: '',
+
+    notice: computed('model.provider.{reviewsWorkflow,documentType}', function () {
+        const reviewsWorkflow = this.get('model.provider.reviewsWorkflow');
+        return this.get('i18n').t(NOTICE_MESSAGE[reviewsWorkflow || NO_MODERATION], {
+            documentType: this.get('model.provider.documentType'),
+        });
+    }),
+
+    withdrawButtonLabel: computed('model.isPublished', function () {
+        return this.get('model.isPublished') ? 'withdraw.withdraw_button_published' : 'withdraw.withdraw_button_not_published';
+    }),
+
+    actions: {
+        cancel() {
+            this.transitionToRoute(
+                `${this.get('theme.isSubRoute') ? 'provider.' : ''}content`,
+                this.get('model'),
+            );
+        },
+    },
+
+    submitWithdrawalRequest: task(function* () {
+        const request = this.store.createRecord('preprint-request', {
+            comment: this.get('explanation'),
+            requestType: 'withdrawal',
+            target: this.get('model'),
+        });
+        try {
+            yield request.save();
+        } catch (e) {
+            this.get('toast').error(e.errors[0].detail);
+            return;
+        }
+        if (!this.get('model.isPublished') && this.get('model.provider.reviewsWorkflow') === PRE_MODERATION) {
+            // If this preprint is not published and the provider is pre-mod.
+            // Transition to the landing page.
+            this.transitionToRoute(`${this.get('theme.isSubRoute') ? 'provider.' : ''}index`);
+            this.get('toast').success(this.get('i18n').t('withdraw.successfully_withdrawn', { documentType: this.get('model.provider.documentType') }));
+        } else {
+            // Go to the detail page once the withdrawal request is successfully submitted.
+            this.transitionToRoute(`${this.get('theme.isSubRoute') ? 'provider.' : ''}content`, this.get('model'));
+        }
+    }),
+});

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1112,6 +1112,12 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
                 this.set('attemptedSubmit', true);
             }
         },
+        clickWithdraw() {
+            this.transitionToRoute(
+                `${this.get('theme.isSubRoute') ? 'provider.' : ''}content.withdraw`,
+                this.get('model'),
+            );
+        },
         savePreprint() {
             // Finalizes saving of preprint.  Publishes preprint.
             this.get('metrics')

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -16,6 +16,7 @@ export default {
         none: 'None',
         abstract: 'Abstract',
         doi: 'DOI',
+        reason_for_withdrawal: 'Reason for withdrawal',
         tags: 'Tags',
         search: 'Search',
         preprints,
@@ -48,6 +49,7 @@ export default {
         header: {
             last_edited: 'Last edited',
             authors_label: 'Authors',
+            withdrawn_on: 'Withdrawn on',
         },
         date_label: {
             created_on: 'Created on',
@@ -255,6 +257,7 @@ export default {
                 cannot_edit: 'You do not have permission to edit this section.',
                 resubmit_button: 'Resubmit',
                 resubmit_help_text: 'Only contributors with admin permissions can resubmit for review.',
+                withdraw_button: 'Withdraw {{documentType.singular}}',
                 return_button: 'Return to {{documentType.singular}}',
             },
             save_continue: 'Save and continue',
@@ -286,6 +289,17 @@ export default {
         server_locked: 'You cannot change the paper service after a file has been uploaded',
         please_select_server: 'Please select a paper service before continuing',
         please_complete_upload: 'Please complete file section before continuing',
+    },
+    withdraw: {
+        heading: 'Withdraw {{documentType.singularCapitalized}}',
+        withdrawal_form_heading: 'Reason for withdrawal (optional):',
+        pre_moderation_notice: 'This service uses pre-moderation. Because of that, your {{documentType.singular}} can be withdrawn at any time even if it\'s still pending approval. If moderation is still pending at the time of withdrawal, your {{documentType.singular}} will be withdrawn without needing moderator approval. It will not have a tombstone page with metadata and the reason for withdrawal and it will not be searchable.',
+        post_moderation_notice: 'This service uses post-moderation. Because of that, your request will need to be approved by a moderation administrator before your {{documentType.singular}} can be withdrawn. If you request is approved, your {{documentType.singular}} will be replaced with a tombstone page with metadata and the reason for withdrawal (if included). Your {{documentType.singular}} will still be searchable by other users.',
+        no_moderation_notice: 'This request will be submitted to support@cos.io for review and removal. Upon removal, this {{documentType.singular}} will be replaced with a tombstone page with metadata and the reason for withdrawal (if included). This {{documentType.singular}} will still be searchable by other users after removal.',
+        withdraw_button_not_published: 'Withdraw',
+        withdraw_button_published: 'Request withdrawal',
+        cancel_button_label: 'Cancel',
+        successfully_withdrawn: 'Your {{documentType.singular}} has been successfully withdrawn.',
     },
     components: {
         'confirm-share-preprint': {
@@ -444,10 +458,13 @@ export default {
                 pending_post: 'is publicly available and searchable but is subject to removal by a moderator',
                 accepted: 'has been accepted by a moderator and is publicly available and searchable',
                 rejected: 'has been rejected by a moderator and is not publicly available or searchable',
+                pending_withdrawal: 'This {{documentType.singular}} has been requested by the authors to be withdrawn. It will still be publicly searchable until the request has been approved.',
+                withdrawn: 'This {{documentType.singular}} has been withdrawn by the author(s).',
             },
             pending: 'pending',
             accepted: 'accepted',
             rejected: 'rejected',
+            pending_withdrawal: 'pending withdrawal',
             feedback: {
                 moderator_feedback: 'Moderator feedback',
                 moderator: 'Moderator',

--- a/app/router.js
+++ b/app/router.js
@@ -91,6 +91,7 @@ Router.map(function() {
         this.route('provider', { path: 'preprints/:slug' }, function () {
             this.route('content', { path: '/:preprint_id' }, function() {
                 this.route('edit');
+                this.route('withdraw');
             });
             this.route('discover');
             this.route('submit');
@@ -102,6 +103,7 @@ Router.map(function() {
 
     this.route('content', { path: '/:preprint_id' }, function() {
         this.route('edit');
+        this.route('withdraw');
     });
 });
 

--- a/app/routes/content/withdraw.js
+++ b/app/routes/content/withdraw.js
@@ -1,0 +1,66 @@
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+import { task } from 'ember-concurrency';
+import CasAuthenticatedRouteMixin from 'ember-osf/mixins/cas-authenticated-route';
+import ConfirmationMixin from 'ember-onbeforeunload/mixins/confirmation';
+import permissions from 'ember-osf/const/permissions';
+import config from 'ember-get-config';
+
+/**
+ * @module ember-preprints
+ * @submodule routes
+ */
+
+/**
+ * Creates a preprint-request record
+ * @class Withdraw Route Handler
+ */
+export default Route.extend(ConfirmationMixin, CasAuthenticatedRouteMixin, { // eslint-disable-line max-len
+    store: service(),
+    i18n: service(),
+    theme: service(),
+    currentUser: service(),
+    preprint: null,
+
+    afterModel(preprint) {
+        this.set('preprint', preprint);
+        if (preprint.get('dateWithdrawn') || preprint.get('reviewsState') === 'rejected') {
+            // if this preprint is withdrawn, then redirect to 'forbidden' page
+            this.replaceWith('forbidden');
+        }
+        return preprint.get('provider')
+            .then(this._getProviderInfo.bind(this))
+            .then(this._getContributors.bind(this))
+            .then(this.get('fetchWithdrawalRequest').perform());
+    },
+    renderTemplate() {
+        this.render('content.withdraw');
+    },
+    fetchWithdrawalRequest: task(function* () {
+        let withdrawalRequest = yield this.get('preprint.requests');
+        withdrawalRequest = withdrawalRequest.toArray();
+        if (withdrawalRequest.length >= 1 && withdrawalRequest[0].get('machineState') === 'pending') {
+            // If there is a pending withdrawal request, then redirect to 'forbidden' page
+            this.replaceWith('forbidden');
+        }
+    }),
+    _getProviderInfo(provider) {
+        const preprint = this.get('preprint');
+        const providerId = provider.get('id');
+        const themeId = this.get('theme.id');
+        const isOSF = providerId === 'osf';
+
+        // If we're not on the proper branded site, redirect.
+        if (themeId !== providerId) {
+            window.location.replace(`${config.OSF.url}${isOSF ? '' : `preprints/${providerId}/`}${preprint.get('id')}/withdraw/`);
+            return Promise.reject();
+        }
+    },
+
+    _getContributors() {
+        const userPermissions = this.get('preprint.currentUserPermissions') || [];
+        if (!userPermissions.includes(permissions.ADMIN)) {
+            this.replaceWith('forbidden'); // Non-admin trying to access withdraw form.
+        }
+    },
+});

--- a/app/routes/provider/content/withdraw.js
+++ b/app/routes/provider/content/withdraw.js
@@ -1,0 +1,13 @@
+import route from '../../content/withdraw';
+
+route.reopen({
+    controllerName: 'content.withdraw',
+    renderTemplate(controller, model) {
+        this.render('content.withdraw', {
+            controller,
+            model,
+        });
+    },
+});
+
+export default route;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -451,6 +451,17 @@ $color-border-light: #DDDDDD;
     }
 }
 
+.preprint-status-withdrawn {
+    background-color: $color-alert-bg-warning;
+    border: 1px solid $color-alert-border-warning;
+    color: $color-alert-text-warning;
+
+    .status-icon {
+        -webkit-text-stroke: 1px $color-alert-text-warning;
+        font-size: 14px;
+    }
+}
+
 .preprint-status-component {
     margin-top: -15px;
     margin-bottom: 15px;
@@ -524,12 +535,16 @@ $color-border-light: #DDDDDD;
 /* SUBMIT page */
 
 .preprint-submit-header {
-    padding-top: 90px;
+    padding-top: 70px;
     background: url("img/submit_bg.jpg") no-repeat top center;
     background-size: cover;
     background-position-y: -50px;
     border-bottom: 1px solid #eee;
     height: 200px;
+    a {
+        color: white;
+        text-decoration: underline;
+    }
 }
 .preprint-submit-body {
     background-color: #f8f8f8;
@@ -867,6 +882,29 @@ hr {
     }
     textarea {
         resize: none;
+    }
+}
+
+.fade.in {
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.preprint-form-section-withdraw-comment {
+    header {
+        font: {
+            size: 16px;
+            font-weight: bold;
+        }
+        color: #337AB7;
+        display: block;
+        margin: 1rem 0;
+    }
+    label > input, label > textarea {
+        font-weight: normal;
+    }
+    textarea {
+        resize: none;
+        height: 150px;
     }
 }
 

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -43,10 +43,17 @@
                                 {{moment-format relevantDate "MMMM DD, YYYY"}}
                             </div>
                             <div class={{if model "detail-header-item" ""}}>
-                                <div class="detail-header-label">
-                                    <strong>{{t "content.header.last_edited"}}</strong>
-                                </div>
-                                {{moment-format model.dateModified "MMMM DD, YYYY"}}
+                                {{#if (not isWithdrawn)}}
+                                    <div class="detail-header-label">
+                                        <strong>{{t "content.header.last_edited"}}</strong>
+                                    </div>
+                                    {{moment-format model.dateModified "MMMM DD, YYYY"}}
+                                {{else}}
+                                    <div class="detail-header-label">
+                                        <strong>{{t "content.header.withdrawn_on"}}</strong>
+                                    </div>
+                                    {{moment-format model.dateWithdrawn "MMMM DD, YYYY"}}
+                                {{/if}}
                             </div>
                             {{#if node}}
                                 <div>
@@ -62,60 +69,62 @@
                         </h6>
                     </div>
                 </div>
-                <div class="col-xs-12 col-sm-2 edit-button-and-logo text-center">
-                    <div class="content-provider-logo provider-{{model.provider.id}} hidden-xs" title="{{model.provider.name}}"></div>
-                    {{#if userIsContrib}}
-                        {{! TODO This link will need to be updated for phase 2 of branding }}
-                        <a type="button"
-                           class="btn btn-success edit-btn"
-                           href={{concat theme.guidPathPrefix model.id '/edit'}}
-                           onclick={{action "click" 'link' "Content - Edit Preprint" (concat model.links.html 'edit')}}
-                        >
-                            {{t editButtonLabel documentType=model.provider.documentType}}
-                        </a>
-                    {{/if}}
-                    <br>
-                </div>
+                {{#if (not isWithdrawn)}}
+                    <div class="col-xs-12 col-sm-2 edit-button-and-logo text-center">
+                        <div class="content-provider-logo provider-{{model.provider.id}} hidden-xs" title="{{model.provider.name}}"></div>
+                        {{#if (and userIsContrib (not isPendingWithdrawal))}}
+                            {{! TODO This link will need to be updated for phase 2 of branding }}
+                            <a type="button"
+                               class="btn btn-success edit-btn"
+                               href={{concat theme.guidPathPrefix model.id '/edit'}}
+                                   onclick={{action "click" 'link' "Content - Edit Preprint" (concat model.links.html 'edit')}}
+                            >
+                                {{t editButtonLabel documentType=model.provider.documentType}}
+                            </a>
+                        {{/if}}
+                        <br>
+                    </div>
+                {{/if}}
             </div>
         </div>
         {{!END CONTAINER DIV}}
     </div>
     {{!END HEADER ROW}}
-    {{#if showStatusBanner}}
-        {{preprint-status-banner submission=model}}
+    {{#if (or showStatusBanner isWithdrawn)}}
+        {{preprint-status-banner submission=model isWithdrawn=isWithdrawn isPendingWithdrawal=isPendingWithdrawal}}
     {{/if}}
     {{!CONTAINER DIV}}
     <div id="view-page" class="container">
-        {{!CONTENT ROW}}
-        <div class="row p-md">
-            {{!LEFT COL DIV}}
-            <div id="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
-                {{#if model.isPreprintOrphan}}
-                    <div class="alert alert-danger m-r-md" role="alert">
-                        {{t "content.orphan_preprint"}}
-                    </div>
-                {{else}}
-                    {{#if (not model.public)}}
+        {{#if (not isWithdrawn)}}
+            {{!CONTENT ROW}}
+            <div class="row p-md">
+                {{!LEFT COL DIV}}
+                <div id="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}">
+                    {{#if model.isPreprintOrphan}}
                         <div class="alert alert-danger m-r-md" role="alert">
-                            {{t "content.private_preprint_warning" documentType=model.provider.documentType supportEmail='support@osf.io'}}
+                            {{t "content.orphan_preprint"}}
                         </div>
+                    {{else}}
+                        {{#if (not model.public)}}
+                            <div class="alert alert-danger m-r-md" role="alert">
+                                {{t "content.private_preprint_warning" documentType=model.provider.documentType supportEmail='support@osf.io'}}
+                            </div>
+                        {{/if}}
+                        {{preprint-file-renderer provider=model.provider preprint=model primaryFile=primaryFile dualTrackNonContributors=(action 'dualTrackNonContributors')}}
+                        <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
+                            <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
+                        </button>
                     {{/if}}
-                    {{preprint-file-renderer provider=model.provider preprint=model primaryFile=primaryFile dualTrackNonContributors=(action 'dualTrackNonContributors')}}
-                    <button class="expand-mfr-carrot hidden-xs hidden-sm" {{action 'expandMFR'}}>
-                        <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
-                    </button>
-                {{/if}}
-            </div>
-            {{!END LEFT COL DIV}}
-            {{#unless fullScreenMFR}}
-                {{!RIGHT SIDE COL}}
-                <div class="col-md-5">
-                    {{!SHARE ROW}}
-                    <div class="share-row p-sm osf-box-lt clearfix">
-                        <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
-                        <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
-                    </div>
-                    <div class="clearfix">
+                </div>
+                {{!END LEFT COL DIV}}
+                {{#unless fullScreenMFR}}
+                    {{!RIGHT SIDE COL}}
+                    <div class="col-md-5">
+                        {{!SHARE ROW}}
+                        <div class="share-row p-sm osf-box-lt clearfix">
+                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
+                            <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
+                        </div>
                         <div class="p-t-md pull-right">
                             {{sharing-icons
                                 title=title
@@ -125,18 +134,133 @@
                                 metricsExtra=metricsExtra
                             }}
                         </div>
-                    </div>
 
-                    {{#if this.isChronosProvider}}
+                        {{!SHARE ROW}}
+                        <div class="share-row p-sm osf-box-lt clearfix">
+                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
+                            <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
+                        </div>
+                        <div class="clearfix">
+                            <div class="p-t-md pull-right">
+                                {{sharing-icons
+                                    title=title
+                                    description=fullDescription
+                                    hyperlink=hyperlink
+                                    facebookAppId=facebookAppId
+                                    metricsExtra=metricsExtra
+                                }}
+                            </div>
+                        </div>
+
+                        {{#if this.isChronosProvider}}
+                            <div class="p-t-xs">
+                                {{#chronos-widget preprint=model isContributor=userIsContrib isAdmin=isAdmin as | preprint submissions isAllowSubmissions isContributor | }}
+                                    {{chronos-submission-status-list submissions=submissions isContributor=isContributor}}
+                                    {{#if isAllowSubmissions }}
+                                        <div class="p-t-xs">
+                                            {{chronos-submission-panel preprint=preprint publisherFilterKeyword="American Psychological Association"}}
+                                        </div>
+                                    {{/if}}
+                                {{/chronos-widget}}
+                            </div>
+                        {{/if}}
                         <div class="p-t-xs">
-                            {{#chronos-widget preprint=model isContributor=userIsContrib isAdmin=isAdmin as | preprint submissions isAllowSubmissions isContributor | }}
-                                {{chronos-submission-status-list submissions=submissions isContributor=isContributor}}
-                                {{#if isAllowSubmissions }}
-                                    <div class="p-t-xs">
-                                        {{chronos-submission-panel preprint=preprint publisherFilterKeyword="American Psychological Association"}}
-                                    </div>
+                            <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
+                            <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
+                                {{~if useShortenedDescription description model.description~}}
+                            </p>
+                            <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
+                                {{~t (if expandedAbstract 'content.see_less' 'content.see_more')~}}
+                            </button>
+                        </div>
+
+                        <div class="p-t-xs">
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi" documentType=model.provider.documentType}}</strong></h4>
+                            {{#if model.preprintDoiUrl}}
+                                {{#if model.preprintDoiCreated}}
+                                    <a href={{model.preprintDoiUrl}} onclick={{action "click" "link" "Content - Preprint DOI" model.preprintDoiUrl}}>{{extract-doi model.preprintDoiUrl}}</a>
+                                {{else}}
+                                    <p> {{extract-doi model.preprintDoiUrl}} </p>
+                                    <p> {{t "content.preprint_pending_doi_minted"}} </p>
                                 {{/if}}
-                            {{/chronos-widget}}
+                            {{else}}
+                                {{#if (not model.public)}}
+                                    {{t 'content.preprint_pending_doi' documentType=model.provider.documentType }}
+                                {{else if (and model.provider.reviewsWorkflow (not model.isPublished))}}
+                                    {{t 'content.preprint_pending_doi_moderation'}}
+                                {{/if}}
+                            {{/if}}
+                        </div>
+
+                        {{#if model.articleDoiUrl}}
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
+                                <a href={{model.articleDoiUrl}} onlick={{action "click" "link" "Content - DOI" model.articleDoiUrl}}>{{extract-doi model.articleDoiUrl}}</a>
+                            </div>
+                        {{/if}}
+
+                        {{#if model.license.name}}
+                            <div class="p-t-xs license-text">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
+                                {{model.license.name}}
+                                <span>
+                                    {{#if showLicenseText }}
+                                        {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
+                                    {{else}}
+                                        {{fa-icon 'caret-right' click=(action 'toggleLicenseText')}}
+                                    {{/if}}
+                                </span>
+                                {{#if showLicenseText}}
+                                    <pre>{{fullLicenseText}}</pre>
+                                {{/if}}
+                            </div>
+                        {{/if}}
+
+                        <div class="p-t-xs">
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
+                            {{#each disciplineReduced as |subject|}}
+                                <span class='subject-preview'>{{subject.text}}</span>
+                            {{/each}}
+                        </div>
+                        <div class="p-t-xs">
+                            <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
+                            {{#if hasTag}}
+                                {{#each model.tags as |tag|}}
+                                    <span class="badge">{{fix-special-char tag}}</span>
+                                {{/each}}
+                            {{else}}
+                                {{t "global.none"}}
+                            {{/if}}
+                        </div>
+
+                        {{#if model.originalPublicationDate}}
+                            <div class="p-t-xs">
+                                <h4 class="p-v-md f-w-md"><strong>{{t "content.original_publication_date"}}</strong></h4>
+                                <p>
+                                    {{moment-format model.originalPublicationDate "YYYY-MM-DD"}}
+                                </p>
+                            </div>
+                        {{/if}}
+
+                        <div class="p-t-xs m-b-lg">
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
+                            {{citation-widget node=model}}
+                        </div>
+                    </div>
+                    {{!END RIGHT SIDE COL}}
+                {{/unless}}
+            </div>
+            {{!END CONTENT ROW}}
+        {{else}}
+            {{! TOMBSTONE PAGE}}
+            <div class="row p-md" style="margin-bottom: 50px">
+                <div class="col-md-5">
+                    {{#if model.withdrawalJustification}}
+                        <div class="p-t-xs">
+                            <h4 class="p-v-md f-w-md"><strong>{{t 'global.reason_for_withdrawal'}}</strong></h4>
+                            <p>
+                                {{model.withdrawalJustification}}
+                            </p>
                         </div>
                     {{/if}}
 
@@ -153,33 +277,15 @@
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi" documentType=model.provider.documentType}}</strong></h4>
                         {{#if model.preprintDoiUrl}}
-                            {{#if model.preprintDoiCreated}}
-                                <a href={{model.preprintDoiUrl}} onclick={{action "click" "link" "Content - Preprint DOI" model.preprintDoiUrl}}>{{extract-doi model.preprintDoiUrl}}</a>
-                            {{else}}
-                                <p> {{extract-doi model.preprintDoiUrl}} </p>
-                                <p> {{t "content.preprint_pending_doi_minted"}} </p>
-                            {{/if}}
-                        {{else}}
-                            {{#if (not model.public)}}
-                                {{t 'content.preprint_pending_doi' documentType=model.provider.documentType }}
-                            {{else if (and model.provider.reviewsWorkflow (not model.isPublished))}}
-                                {{t 'content.preprint_pending_doi_moderation'}}
-                            {{/if}}
+                            <p> {{extract-doi model.preprintDoiUrl}} </p>
                         {{/if}}
                     </div>
 
-                    {{#if model.articleDoiUrl}}
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
-                            <a href={{model.articleDoiUrl}} onlick={{action "click" "link" "Content - DOI" model.articleDoiUrl}}>{{extract-doi model.articleDoiUrl}}</a>
-                        </div>
-                    {{/if}}
-
                     {{#if model.license.name}}
-                        <div class="p-t-xs license-text">
+                        <div class="p-t-xs">
                             <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
                             {{model.license.name}}
-                            <span>
+                            <span style='cursor: pointer'>
                                 {{#if showLicenseText }}
                                     {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
                                 {{else}}
@@ -187,17 +293,17 @@
                                 {{/if}}
                             </span>
                             {{#if showLicenseText}}
-                                <pre>{{fullLicenseText}}</pre>
+                                <pre style='white-space: pre-wrap; font-size:75%; border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
                             {{/if}}
                         </div>
                     {{/if}}
-
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
                         {{#each disciplineReduced as |subject|}}
                             <span class='subject-preview'>{{subject.text}}</span>
                         {{/each}}
                     </div>
+
                     <div class="p-t-xs">
                         <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
                         {{#if hasTag}}
@@ -208,25 +314,10 @@
                             {{t "global.none"}}
                         {{/if}}
                     </div>
-
-                    {{#if model.originalPublicationDate}}
-                        <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md"><strong>{{t "content.original_publication_date"}}</strong></h4>
-                            <p>
-                                {{moment-format model.originalPublicationDate "YYYY-MM-DD"}}
-                            </p>
-                        </div>
-                    {{/if}}
-
-                    <div class="p-t-xs m-b-lg">
-                        <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
-                        {{citation-widget node=model}}
-                    </div>
                 </div>
-                {{!END RIGHT SIDE COL}}
-            {{/unless}}
-        </div>
-        {{!END CONTENT ROW}}
+            </div>
+            {{! END TOMBSTONE PAGE}}
+        {{/if}}
     </div>
     {{!END DIV CONTAINER}}
 </div>

--- a/app/templates/content/withdraw.hbs
+++ b/app/templates/content/withdraw.hbs
@@ -1,0 +1,40 @@
+{{title 'Withdraw'}}
+<div class="preprint-submit-header">
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12 col-md-10 col-md-offset-1 ">
+                {{#if editMode}}
+                    <i class="fa fa-long-arrow-left" aria-hidden="true"></i>
+                    <a role="button" {{action 'returnToSubmission'}}>{{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}</a>
+                {{/if}}
+            </div>
+            <div class="col-xs-12 text-center">
+                <h1>{{t "withdraw.heading" documentType=theme.provider.documentType}}</h1>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="preprint-submit-body">
+    <div class="container">
+        <div class="row m-t-lg">
+            <div class="col-xs-12 col-md-10 col-md-offset-1">
+                <p> {{ notice }} </p>
+                <section class="preprint-form-block preprint-form-section-withdraw-comment">
+                    <header>
+                        {{ t 'withdraw.withdrawal_form_heading' }}
+                    </header>
+                    {{textarea value=explanation class="form-control"}}
+                </section>
+
+                <div class="submit-section">
+                    <button class="btn btn-danger btn-md m-t-md pull-right" onclick={{perform submitWithdrawalRequest}}>
+                        {{ t withdrawButtonLabel }}
+                    </button>
+                    <button class="btn btn-default btn-md m-t-md pull-right" onclick={{action 'cancel'}}>
+                        {{ t 'withdraw.cancel_button_label' }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -3,6 +3,12 @@
 <div class="preprint-submit-header">
     <div class="container">
         <div class="row">
+            <div class="col-xs-12 col-md-10 col-md-offset-1 ">
+                {{#if editMode}}
+                    {{fa-icon 'long-arrow-left'}}
+                    <a role="button" {{action 'returnToSubmission'}}>{{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}</a>
+                {{/if}}
+            </div>
             <div class="col-xs-12 text-center">
                 <h1>{{t (if editMode "submit.edit_heading" heading) documentType=currentProvider.documentType}}</h1>
             </div>
@@ -342,9 +348,11 @@
                                     }}
                                 </div>
                             {{/if}}
-                            <button class="btn btn-primary btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'returnToSubmission'}}>
-                                {{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}
-                            </button>
+
+                            {{#if (not (eq model.reviewsState 'rejected'))}}
+                                {{!-- Only shows the 'Withdraw preprint' button iff the preprint is not in a rejected state --}}
+                                <button class="btn {{if canResubmit 'btn-default' 'btn-danger'}} btn-md m-t-md pull-right" {{action 'clickWithdraw'}}> {{t "submit.body.edit.withdraw_button" documentType=currentProvider.documentType}} </button>
+                            {{/if}}
                         </div>
                     {{else}}
                         <strong><p class="information">{{t permissionInformation documentType=currentProvider.documentType name=providerName}}</p></strong>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hotfix": "git flow hotfix start rename-me && npm --no-git-tag-version version patch && git ci package.json -m 'Bump version' && git br -m \"hotfix/$(npm version | head -1 | grep -o '[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+')\""
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf#26d7c4641bca211defdba177902c3479f8f78e65",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-03-13T20:48:34Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "autoprefixer": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,9 +183,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf#26d7c4641bca211defdba177902c3479f8f78e65":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-03-13T20:48:34Z":
   version "0.23.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf#26d7c4641bca211defdba177902c3479f8f78e65"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#a9791d5bdc84384cd0d0103e312fbc07f1863dd0"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

This PR adds functionality for preprint contributors to request withdrawal of a certain preprint.

## Summary of Changes

To allow contributors to request withdrawal of a certain preprint, the following changes are made:

- A new `withdraw` view with route `/withdraw` is added.
- The `submit/edit` view is changed so that uses can navigate to the `withdraw` view.
- The `index` view (preprint detail) is changed so that the status bar shows `pending withdrawal` status. It also shows the tombstone page if the preprint is withdrawn.
  - The `preprint-status-banner` component is changed to show the `pending withdrawal` message.

The changes above are detailed below, respectively:

- For the `withdraw` view,
  - Two route files, `routes/content/withdraw.js`, `routes/provider/content/withdraw.js` (for custom domain providers) are added. 
  - `controllers/withdraw.js` is added as the `withdraw` view's controller.
  - `templates/content/withdraw.hbs` is added as the template.
- For the `submit/edit` view,
  - The route file `routes/content/edit.js` is modified so that users cannot go to the `edit` view of a withdrawn/pending withdrawal preprint. Instead a `forbidden` page is shown.
  - The template file `templates/submit.hbs` is modified to show the `return to preprint` button on the top left side of the view. A `Withdraw` or `Request withdrawal` button is added to the bottom of the page for redirecting to the `withdraw` view.
  - The controller file `controllers/submit.js` is changed to implement redirection to `withdraw` view.
- For the `index` (preprint detail) view,
  - The route file `routes/content/index.js` is modified to set `isPendingWithdrawal` for preprints with an pending withdrawal request. It also sets `isWithdrawn` for withdrawn preprints.
  - The controller file `controllers/content/index.js` is modified to show status banner for pending withdrawal preprint by looking at `isPendingWithdrawal`.
    - The `preprint-status-banner` component is also changed to show correct status message by looking at `isPendingWithdrawal`
  - The template file `templates/content/index.hbs` is modified to show a tombstone page for withdrawn preprints.
- Miscellaneous CSS file changes and tranlations string changes are not detailed here.


## Testing Notes

A full test to see if the preprint withdrawal request functionality is working for the Preprints app. Need to test along with Reviews side.
Two things to note:
1. Only published preprints without pending withdrawal requests can be requested for withdrawal.
2. Not-yet-published preprints' withdrawal requests should be automatically approved.

## Ticket

https://openscience.atlassian.net/browse/IN-328
https://openscience.atlassian.net/browse/IN-304

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
