### PR TITLE
[IN-273][Preprints] Add 'My Preprints' link to branded navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - add `isWithdrawn` to google anlaytics pageTracking
 - ability to download previous preprint (primary file) versions
 - contributor query using elastic endpoint
+- `My Preprints` link to the branded navbar
 
 ### Fixed
 - word break in license text
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - branded footer line-height
 - Manual sorting of taxonomies
+- `My OSF Projects` from the branded navbar
 
 ## [0.121.0] - 2018-08-16
 ### Added

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -386,7 +386,7 @@ export default {
             toggle: 'Toggle navigation',
         },
         'preprint-navbar-branded': {
-            my_projects: 'My OSF Projects',
+            my_preprints: 'My Preprints',
             headline: 'On the OSF',
             reviews: 'My Reviewing',
             donate: 'Donate',

--- a/app/locales/es-disabled/translations.js
+++ b/app/locales/es-disabled/translations.js
@@ -333,7 +333,7 @@ export default {
             toggle: 'Cambiar la navegación',
         },
         'preprint-navbar-branded': {
-            my_projects: 'Mis Proyectos OSF',
+            my_preprints: 'Mis Preprints',
             headline: 'En la OSF',
         },
         'project-chooser': {

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -14,7 +14,7 @@
     <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
         <ul class="nav navbar-nav branded-nav">
             {{#if session.isAuthenticated}}
-                <li><a href="{{host}}myprojects/" class="" onbeforeclick={{action "click" "link" "Navbar - My OSF Projects"}}>{{t "components.preprint-navbar-branded.my_projects"}}</a></li>
+                <li><a href="{{host}}myprojects/#preprints" class="" onbeforeclick={{action "click" "link" "Navbar - My Preprints"}}>{{t "components.preprint-navbar-branded.my_preprints"}}</a></li>
             {{/if}}
             {{#if theme.provider.allowSubmissions}}
                 <li><a href={{concat theme.pathPrefix 'submit'}} onbeforeclick={{action "click" "link" "Navbar - Add preprint"}}>{{t submitLabel documentType=theme.provider.documentType}}</a></li>


### PR DESCRIPTION
## Purpose
To update the branded navbar to match the non-branded version.


## Summary of Changes/Side Effects
- Added `My Preprints` link
- Removed `My OSF Projects` link
- Updated translations


## Testing Notes
Please make sure that the link takes you to the right anchor on the My Projects page and that the navbar breaks to the smaller version when it needs to.


## Ticket

https://openscience.atlassian.net/browse/IN-273

## Notes for Reviewer
`N/A`

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
