### PR TITLE
[IN-459][Preprints] Fix subject filter on edit/submit page

### DIFF
--- a/app/components/subject-picker/component.js
+++ b/app/components/subject-picker/component.js
@@ -28,7 +28,7 @@ const Column = EmberObject.extend({
             return subjects;
         }
 
-        return subjects.filter(item => item.get('text').toLowerCase().includes(filterTextLowerCase));
+        return subjects !== null ? subjects.filter(item => item.get('text').toLowerCase().includes(filterTextLowerCase)) : null;
     }),
     init() {
         this._super(...arguments);


### PR DESCRIPTION
## Purpose
Filtering when there aren't any subjects is breaking the submit/edit page.


## Summary of Changes/Side Effects
- Add a check for subjects before trying to return a filtered list


## Testing Notes
The issue before was that this would try to filter subjects that weren't existent and caused a glimmer error that would break the page.  By fixing the filter, you should notice that even when you try to filter a box without subjects the page won't break and you can finish the form.

- Create a new preprint
- Select engrxiv as the provider
- Complete form up to the subjects
- Select `Engineering` in the first box and `Other Engineering` in the second
- Notice that there aren't any subjects appearing in the third box
- Try filtering in the third box.  Notice that there aren't any errors in the console
- Save subjects
- Reopen subject section and try adding a new subject.  Notice that it lets you make changes.
- Finish the form and save

- Go edit the preprint
- Go to subjects and select `Engineering` -> `Other Engineering`
- Try to filter third box.  Notice that there aren't any errors.
- Save subjects
- Reopen subject section and add a new subject.  Notice that it lets you add/remove subjects.
- Finish and save

## Ticket

https://openscience.atlassian.net/browse/IN-459

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
