### PR TITLE
[IN-131][Preprints] Fix license text formatting

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -336,7 +336,7 @@ $logo-dir: 'img/provider_logos/';
             width:100%;
             text-align:justify;
             max-height: 300px;
-            word-break: break-word;
+            word-break: normal;
         }
         span {
             cursor: pointer;


### PR DESCRIPTION
## Purpose
Fix the license text formatting on the preprint-detail page to also work on Firefox, IE, and Edge.


## Summary of Changes/Side Effects
- Change `word-break: break-word` to `word-break: normal`


## Testing Notes
This should affect the license text on the detail page.  It should break the whole word to a new line instead of break it in the middle of a word.


*Screenshot taken in Firefox 62*
<img width="457" alt="screen shot 2018-09-13 at 4 33 09 pm" src="https://user-images.githubusercontent.com/19379783/45514204-c12e6c80-b772-11e8-87d2-8ab702970d4d.png">


## Ticket

https://openscience.atlassian.net/browse/IN-131

## Notes for Reviewer
`N/A`


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
