### PR TITLE
[IN-363][Preprints] Fix primary file versions downloadUrl

### DIFF
--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -184,6 +184,12 @@ export default Component.extend(Analytics, {
     },
     __serializeVersions(versions) {
         const downloadUrl = this.get('selectedFile.links.download');
+        const selectedFileGuid = this.get('selectedFile.guid');
+
+        const directDownloadUrl = downloadUrl.replace(
+            `download/${selectedFileGuid}`,
+            `${selectedFileGuid}/download`,
+        );
         const filename = this.get('selectedFile.name');
 
         if (this.get('selectedFileIsPrimaryFile')) {
@@ -194,7 +200,7 @@ export default Component.extend(Analytics, {
             .map((version) => {
                 const dateFormatted = encodeURIComponent(version.get('dateCreated').toISOString());
                 const displayName = filename.replace(/(\.\w+)?$/, ext => `-${dateFormatted}${ext}`);
-                version.set('downloadUrl', `${downloadUrl}?version=${version.id}&displayName=${displayName}`);
+                version.set('downloadUrl', `${directDownloadUrl}?version=${version.id}&displayName=${displayName}`);
                 return version;
             });
     },


### PR DESCRIPTION
## Purpose

Currently, when using non-direct file download URL such as https://staging2.osf.io/download/mejtw/?version=5&displayName=job-posts-lingo-2018-09-10T13%3A48%3A57.210Z.jpeg, the downloaded file still preserves the original name "job-posts-lingo.jpeg" as opposed to what's passed in `displayName` i.e "job-posts-lingo-2018-09-10T13:48:57.210Z.jpeg".

This is a workaround WB bug [SVCS-916](https://openscience.atlassian.net/browse/SVCS-916)
suggested by Fitz. 

## Summary of Changes/Side Effects
Use direct download url by swapping file guid and "download"
So https://staging2.osf.io/download/mejtw/?version=5&displayName=job-posts-lingo-2018-09-10T13%3A48%3A57.210Z.jpeg
becomes
https://staging2.osf.io/mejtw/download/?version=5&displayName=job-posts-lingo-2018-09-10T13%3A48%3A57.210Z.jpeg

## Testing Notes

Please make sure the downloaded preprint (primary file) version has the date created appended to original name.

## Ticket

[IN-363](https://openscience.atlassian.net/browse/IN-363)

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
