### PR TITLE
[IN-472][Preprints] Fix selected provider name on submit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - word break in license text
+- provider name on submit form header
 
 ### Removed
 - branded footer line-height

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -26,7 +26,7 @@
             <em class="m-r-md"> {{t "components.preprint-form-header.server"}}: </em>
             {{#if currentProvider}}
                 <img alt="provider logo" class="current-provider" title="{{currentProvider.name}}" src={{provider-asset currentProvider.id 'square_color_no_transparent.png'}}>
-                {{if (not theme.isProvider) 'OSF Preprints' currentProvider.name}}
+                {{if (eq currentProvider.name 'Open Science Framework') 'OSF Preprints' currentProvider.name}}
             {{/if}}
         </p>
     </div>


### PR DESCRIPTION
## Purpose

Fix selected provider name on submit form.

Currently, on the submit form (provider section), after selecting a provider and moving on to the next section/pane, the name stays OSF Preprints with the logo of the selected provider.

## Summary of Changes/Side Effects

- Replace `theme.isProvider` check with `provider.name` check.
- Update changelog

## Testing Notes
Please make sure both logo and provider name correspond to the selected provider after selecting provider and moving on to 'upload'.

## Ticket

[IN-472](https://openscience.atlassian.net/browse/IN-472)

## Notes for Reviewer

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [x] changes described in `CHANGELOG.md`
