### PR TITLE
[Hotfix][IN-479][Preprints] Change metatag from `citation_publication_date` to `citation_online_date`.

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -180,7 +180,7 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
             ['citation_title', title],
             ['citation_description', description],
             ['citation_public_url', canonicalUrl],
-            ['citation_publication_date', `${dateCreated.getFullYear()}/${dateCreated.getMonth() + 1}/${dateCreated.getDate()}`],
+            ['citation_online_date', `${dateCreated.getFullYear()}/${dateCreated.getMonth() + 1}/${dateCreated.getDate()}`],
         ];
         if (doi) {
             highwirePress.push(['citation_doi', doi]);


### PR DESCRIPTION
## Purpose

Change metatag from `citation_publication_date` to `citation_online_date` to allow Google scholar to better index our Preprints.


## Summary of Changes/Side Effects

Same as above.

## Ticket

https://openscience.atlassian.net/browse/IN-479

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
