### PR TITLE
[Chronos] Bypass popup blocker

### DIFF
--- a/app/components/chronos-submission-panel/component.js
+++ b/app/components/chronos-submission-panel/component.js
@@ -60,13 +60,14 @@ export default Component.extend({
         this.set('canLoadMore', canLoadMore);
     }).enqueue(),
     _submit: task(function* () {
+        const newTab = window.open();
         const submission = this.get('store').createRecord('chronos-submission', {
             journal: this.get('selectedJournal'),
             preprint: this.get('preprint'),
         });
         try {
             yield submission.save();
-            window.open(submission.get('submissionUrl'));
+            newTab.location.href = submission.get('submissionUrl');
             window.location.reload(true);
         } catch (e) {
             this.get('toast').error(e.errors[0].detail);


### PR DESCRIPTION
## Purpose

Chrome blocks new tab (popups) if it is not a result of a direct user action. This PR avoids that by first opening a new tab, then redirects the new tab to the url returned when a Chronos submission is completed.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
