### PR TITLE
Fix/Divorce - Rendering of Preprint File [IN-98]

### DIFF
--- a/app/components/preprint-file-renderer.js
+++ b/app/components/preprint-file-renderer.js
@@ -5,7 +5,6 @@ import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import loadAll from 'ember-osf/utils/load-relationship';
 import Analytics from 'ember-osf/mixins/analytics';
-import fileDownloadPath from '../utils/file-download-path';
 
 /**
  * @module ember-preprints
@@ -52,10 +51,6 @@ export default Component.extend(Analytics, {
             promise: loadAll(primaryFile, 'versions', versions, { sort: '-id', 'page[size]': 50 })
                 .then(this.__serializeVersions.bind(this, versions)),
         });
-    }),
-
-    fileDownloadURL: computed('primaryFile', function() {
-        return fileDownloadPath(this.get('primaryFile'), this.get('preprint'));
     }),
 
     didReceiveAttrs() {

--- a/app/templates/components/preprint-file-renderer.hbs
+++ b/app/templates/components/preprint-file-renderer.hbs
@@ -1,5 +1,5 @@
 {{#file-renderer
-    download=fileDownloadURL
+    download=primaryFile.links.download
     allowCommenting=allowCommenting
     width="99%"
     height="700"}}


### PR DESCRIPTION
## Purpose
<!-- Why is this change necessary? What does it do? -->
Instead of building url to pass to MFR, pull url off of primary file download links (similar to pre-divorce, except it was pulling off of selectedFile.

## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
This should be an improvement, and closer to what we have on prod (prior to the divorce). Building the download URL manually worked fine locally, but was failing on staging3. 

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->


## Ticket

https://openscience.atlassian.net/browse/IN-

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
