### PR TITLE
[EMB-413][Preprints] use `dateCreated` as the submitted date.

### DIFF
--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -71,11 +71,7 @@ export default Controller.extend(Analytics, {
             DATE_LABEL.submitted :
             DATE_LABEL.created;
     }),
-    relevantDate: computed('model.provider.reviewsWorkflow', function() {
-        return this.get('model.provider.reviewsWorkflow') ?
-            this.get('model.dateLastTransitioned') :
-            this.get('model.dateCreated');
-    }),
+    relevantDate: computed.alias('model.dateCreated'),
 
     editButtonLabel: computed('model.{provider.reviewsWorkflow,reviewsState}', function () {
         const editPreprint = 'content.project_button.edit_preprint';


### PR DESCRIPTION
## Purpose

Right now, the `created on` date for post moderation preprints is the `dateLastTransitioned`. This PR changes to using `dateCreated`.

## Changes

Same as above.

## Ticket

https://openscience.atlassian.net/browse/EMB-413
