### PR TITLE
[hotfix][no ticket] fix(perf): don't block render waiting for <meta>

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -43,6 +43,8 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
     preprint: null,
     contributors: A(),
 
+    waitForMetaData: navigator.userAgent.includes('Prerender'),
+
     afterModel(preprint) {
         const { location: { origin } } = window;
 
@@ -59,10 +61,12 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
         this.set('fileDownloadURL', downloadUrl);
         this.set('preprint', preprint);
 
-        return preprint.get('provider')
+        const setupMetaData = preprint.get('provider')
             .then(this._getProviderDetails.bind(this))
             .then(this._getUserPermissions.bind(this))
             .then(this._setupMetaData.bind(this));
+
+        return this.get('waitForMetaData') ? setupMetaData : undefined;
     },
 
     setupController(controller, model) {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make it render less slooooowly
<!-- Why is this change necessary? What does it do? -->


## Summary of Changes/Side Effects
<!-- What did you change?
Include before/after screenshots or a video/gif if applicable.
Do these changes have any unforseen effects (good or bad)?-->
Previously, would block rendering waiting for all contributors to load and be inserted in `<meta>` tags. This is neither necessary nor helpful outside of prerender. Only block like that in prerender.

There are deeper problems here this PR does not attempt to fix. For example:
- We should avoid loading the full list of contributors
- If we have to load the full list of contributors, we should do it only once, not twice
- The list of contributors in `<meta>` tags is filtered to bibliographic contributors only. Should the displayed list of contributors be filtered also?

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->
`<meta>` tags for all contributors should still be there, contributors should still load, the page should render faster.

## Ticket
n/a

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
