### PR TITLE
[EMB-482][Preprints] `citation_doi` metatag should always use preprints doi.

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -148,7 +148,6 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
         const facebookAppId = provider.get('facebookAppId') || config.FB_APP_ID;
         const mintDoi = extractDoiFromString(preprint.get('preprintDoiUrl'));
         const peerDoi = preprint.get('doi');
-        const doi = peerDoi || mintDoi;
         const image = this.get('theme.logoSharing');
         const imageUrl = /^https?:\/\//.test(image.path) ? image.path : origin + image.path;
         const dateCreated = new Date(preprint.get('dateCreated') || null);
@@ -185,8 +184,8 @@ export default Route.extend(Analytics, ResetScrollMixin, SetupSubmitControllerMi
             ['citation_public_url', canonicalUrl],
             ['citation_online_date', `${dateCreated.getFullYear()}/${dateCreated.getMonth() + 1}/${dateCreated.getDate()}`],
         ];
-        if (doi) {
-            highwirePress.push(['citation_doi', doi]);
+        if (mintDoi) {
+            highwirePress.push(['citation_doi', mintDoi]);
         }
 
         // TODO map Eprints fields


### PR DESCRIPTION
## Purpose

This PR makes sure that `citation_doi` metatag is alwasy the preprint doi.

## Ticket

https://openscience.atlassian.net/browse/EMB-482


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
