### PR TITLE
[No ticket] Add documentType to `fakeProvider` stub

### DIFF
--- a/tests/integration/components/preprint-navbar-branded-test.js
+++ b/tests/integration/components/preprint-navbar-branded-test.js
@@ -8,6 +8,12 @@ const fakeProvider = {
     id: 'pandaXriv',
     name: 'The Panda Archive of bamboo',
     isProvider: true,
+    documentType: {
+        singular: 'fake',
+        plural: 'fakes',
+        singularCapitalized: 'Fake',
+        pluralCapitalized: 'Fakes',
+    },
 };
 
 // Stub theme service


### PR DESCRIPTION
## Purpose
Try to fix the annoying test failures [here](https://travis-ci.org/CenterForOpenScience/ember-osf-preprints/builds/486610124).

## Summary of Changes/Side Effects
Cannot reproduce the test failures locally. However I've encountered similar problems before. The fix seems to be adding the `documentType` in the provider stub for tests. Don't know whether this will fix the problem, but it wouldn't hurt.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
