### PR TITLE
refactor: enable Chronos for providers from config

### DIFF
--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -164,6 +164,11 @@ export default Controller.extend(Analytics, {
         return `mailto:?subject=${titleEncoded}&body=${hrefEncoded}`;
     }),
 
+    isChronosProvider: computed('model.provider.id', function() {
+        const { chronosProviders } = config;
+        return Array.isArray(chronosProviders) && chronosProviders.includes(this.get('model.provider.id'));
+    }),
+
     actions: {
         toggleLicenseText() {
             const licenseState = this.toggleProperty('showLicenseText') ? 'Expand' : 'Contract';

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -127,18 +127,18 @@
                         </div>
                     </div>
 
-                    <div class="p-t-xs">
-                        {{#chronos-widget preprint=model isContributor=userIsContrib isAdmin=isAdmin as | preprint submissions isAllowSubmissions isContributor | }}
-                            {{chronos-submission-status-list submissions=submissions isContributor=isContributor}}
-                            {{#if (eq preprint.provider.id "psyarxiv")}}
+                    {{#if this.isChronosProvider}}
+                        <div class="p-t-xs">
+                            {{#chronos-widget preprint=model isContributor=userIsContrib isAdmin=isAdmin as | preprint submissions isAllowSubmissions isContributor | }}
+                                {{chronos-submission-status-list submissions=submissions isContributor=isContributor}}
                                 {{#if isAllowSubmissions }}
                                     <div class="p-t-xs">
                                         {{chronos-submission-panel preprint=preprint publisherFilterKeyword="American Psychological Association"}}
                                     </div>
                                 {{/if}}
-                            {{/if}}
-                        {{/chronos-widget}}
-                    </div>
+                            {{/chronos-widget}}
+                        </div>
+                    {{/if}}
 
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>

--- a/config/environment.js
+++ b/config/environment.js
@@ -93,6 +93,8 @@ module.exports = function(environment) {
             'Research Papers in Economics',
             'Preprints.org',
         ],
+        chronosProviders: [
+        ],
         approvedChronosJournalIds: [
             '0147-7307',
             '1099-9809',


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This moves enabling of Chronos submission to be based on a list of providers in config.

## Summary of Changes/Side Effects

* create `isChronosProvider` computed property to look for preprint provider in config.
* conditionally render the chronos-widget based on this property

(this means that Chronos will not be enable for psyarxiv until it's added to config)

## Testing Notes

Need to make sure Chronos submission still functions for psyarxiv (once configured)

## Ticket

n/a

## Notes for Reviewer

Should make sure Chronos submission is enabled *only* when configured.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
