### PR TITLE
fix: remove duplicate share row

### DIFF
--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -125,21 +125,6 @@
                             <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
                             <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
                         </div>
-                        <div class="p-t-md pull-right">
-                            {{sharing-icons
-                                title=title
-                                description=fullDescription
-                                hyperlink=hyperlink
-                                facebookAppId=facebookAppId
-                                metricsExtra=metricsExtra
-                            }}
-                        </div>
-
-                        {{!SHARE ROW}}
-                        <div class="share-row p-sm osf-box-lt clearfix">
-                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
-                            <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
-                        </div>
                         <div class="clearfix">
                             <div class="p-t-md pull-right">
                                 {{sharing-icons


### PR DESCRIPTION
## Purpose

A bad merge conflict resolution resulted in duplicate share rows on the preprint detail page.

## Summary of Changes/Side Effects

Remove duplicate share row from preprint content page.

## Testing Notes

make sure there's not two share rows on preprint detail page.

## Ticket

n/a

## Notes for Reviewer

n/a

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
