### PR TITLE
[EMB-548][ENG-233][ENG-237][Preprint Withdrawals] Fix languages and buttons.

### DIFF
--- a/app/controllers/content/withdraw.js
+++ b/app/controllers/content/withdraw.js
@@ -3,12 +3,15 @@ import { task } from 'ember-concurrency';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
+const PRE_MODERATION_ACCEPTED = 'pre-moderation-accepted';
+const PRE_MODERATION_PENDING = 'pre-moderation-pending';
 const PRE_MODERATION = 'pre-moderation';
 const POST_MODERATION = 'post-moderation';
 const NO_MODERATION = 'no-moderation';
 
 const NOTICE_MESSAGE = {
-    [PRE_MODERATION]: 'withdraw.pre_moderation_notice',
+    [PRE_MODERATION_ACCEPTED]: 'withdraw.pre_moderation_notice_accepted',
+    [PRE_MODERATION_PENDING]: 'withdraw.pre_moderation_notice_pending',
     [POST_MODERATION]: 'withdraw.post_moderation_notice',
     [NO_MODERATION]: 'withdraw.no_moderation_notice',
 };
@@ -23,7 +26,8 @@ export default Controller.extend({
 
     notice: computed('model.provider.{reviewsWorkflow,documentType}', function () {
         const reviewsWorkflow = this.get('model.provider.reviewsWorkflow');
-        return this.get('i18n').t(NOTICE_MESSAGE[reviewsWorkflow || NO_MODERATION], {
+        const reviewsState = this.get('model.reviewsState');
+        return this.get('i18n').t(NOTICE_MESSAGE[`${reviewsWorkflow}-${reviewsState}` || NO_MODERATION], {
             documentType: this.get('model.provider.documentType'),
         });
     }),

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -514,6 +514,10 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
         const state = this.get('model.reviewsState');
         return this.get('moderationType') === PRE_MODERATION && (state === PENDING || state === REJECTED) && this.get('isAdmin');
     }),
+    canWithdraw: computed('moderationType', 'model.reviewsState', function() {
+        const state = this.get('model.reviewsState');
+        return (state === PENDING || state === ACCEPTED) && this.get('isAdmin');
+    }),
 
     actions: {
         getProjectContributors(node) {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -293,7 +293,8 @@ export default {
     withdraw: {
         heading: 'Withdraw {{documentType.singularCapitalized}}',
         withdrawal_form_heading: 'Reason for withdrawal (optional):',
-        pre_moderation_notice: 'This service uses pre-moderation. Because of that, your {{documentType.singular}} can be withdrawn at any time even if it\'s still pending approval. If moderation is still pending at the time of withdrawal, your {{documentType.singular}} will be withdrawn without needing moderator approval. It will not have a tombstone page with metadata and the reason for withdrawal and it will not be searchable.',
+        pre_moderation_notice_pending: 'Your {{documentType.singular}} is still pending approval and thus private, but can be withdrawn immediately. If you wish to provide a reason for withdrawal, it will be displayed only to service moderators. Once withdrawn, your preprint will never be made public.',
+        pre_moderation_notice_accepted: 'This service uses pre-moderation. Your {{documentType.singular}} must be approved by a moderator. Once approved, your {{documentType.singular}} will be removed, but basic metadata (like title, authors, and reason for withdrawal, if provided) will remain.',
         post_moderation_notice: 'This service uses post-moderation. Because of that, your request will need to be approved by a moderation administrator before your {{documentType.singular}} can be withdrawn. If you request is approved, your {{documentType.singular}} will be replaced with a tombstone page with metadata and the reason for withdrawal (if included). Your {{documentType.singular}} will still be searchable by other users.',
         no_moderation_notice: 'This request will be submitted to support@cos.io for review and removal. Upon removal, this {{documentType.singular}} will be replaced with a tombstone page with metadata and the reason for withdrawal (if included). This {{documentType.singular}} will still be searchable by other users after removal.',
         withdraw_button_not_published: 'Withdraw',
@@ -459,7 +460,7 @@ export default {
                 accepted: 'has been accepted by a moderator and is publicly available and searchable',
                 rejected: 'has been rejected by a moderator and is not publicly available or searchable',
                 pending_withdrawal: 'This {{documentType.singular}} has been requested by the authors to be withdrawn. It will still be publicly searchable until the request has been approved.',
-                withdrawn: 'This {{documentType.singular}} has been withdrawn by the author(s).',
+                withdrawn: 'This {{documentType.singular}} has been withdrawn.',
             },
             pending: 'pending',
             accepted: 'accepted',

--- a/app/templates/content/withdraw.hbs
+++ b/app/templates/content/withdraw.hbs
@@ -2,12 +2,6 @@
 <div class="preprint-submit-header">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-md-10 col-md-offset-1 ">
-                {{#if editMode}}
-                    <i class="fa fa-long-arrow-left" aria-hidden="true"></i>
-                    <a role="button" {{action 'returnToSubmission'}}>{{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}</a>
-                {{/if}}
-            </div>
             <div class="col-xs-12 text-center">
                 <h1>{{t "withdraw.heading" documentType=theme.provider.documentType}}</h1>
             </div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -3,12 +3,6 @@
 <div class="preprint-submit-header">
     <div class="container">
         <div class="row">
-            <div class="col-xs-12 col-md-10 col-md-offset-1 ">
-                {{#if editMode}}
-                    {{fa-icon 'long-arrow-left'}}
-                    <a role="button" {{action 'returnToSubmission'}}>{{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}</a>
-                {{/if}}
-            </div>
             <div class="col-xs-12 text-center">
                 <h1>{{t (if editMode "submit.edit_heading" heading) documentType=currentProvider.documentType}}</h1>
             </div>
@@ -322,74 +316,79 @@
                 {{/cp-panels}}
 
                 <div class="submit-section">
-                    {{#if editMode}}
-                        <div>
-                            {{#if showInformation}}
-                                <p>{{t editInformation1 documentType=currentProvider.documentType name=providerName reviewsWorkflow=(t workflow)}}</p>
-                                <p>
-                                    {{t editInformation2
-                                        name=providerName
-                                        reviewsWorkflow=(t workflow)
-                                        email=theme.provider.emailSupport}}
+                    {{#if currentProvider}}
+                        {{#if editMode}}
+                            <div>
+                                {{#if showInformation}}
+                                    <p>{{t editInformation1 documentType=currentProvider.documentType name=providerName reviewsWorkflow=(t workflow)}}</p>
+                                    <p>
+                                        {{t editInformation2
+                                            name=providerName
+                                            reviewsWorkflow=(t workflow)
+                                            email=theme.provider.emailSupport}}
+                                    </p>
+                                {{/if}}
+                                <button class="btn btn-default btn-md m-t-md pull-right" {{action 'returnToSubmission'}}>{{t "submit.body.edit.return_button" documentType=currentProvider.documentType}}</button>
+                                {{#if canResubmit}}
+                                    <button class="btn btn-success btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'clickSubmit'}}>
+                                        {{t "submit.body.edit.resubmit_button"}}
+                                    </button>
+                                    <div>
+                                        {{confirm-share-preprint
+                                            isOpen=showModalSharePreprint
+                                            shareButtonDisabled=shareButtonDisabled
+                                            savePreprint=(action 'resubmit')
+                                            buttonLabel="submit.body.edit.resubmit_button"
+                                            title=modalTitle
+                                            documentType=currentProvider.documentType
+                                        }}
+                                    </div>
+                                {{/if}}
+
+                                {{#if (not (eq model.reviewsState 'rejected'))}}
+                                    {{#if canWithdraw}}
+                                        {{!-- Only shows the 'Withdraw preprint' button iff the preprint is not in a rejected state, and the user has permission --}}
+                                        <button class="btn btn-danger btn-md m-t-md pull-right" {{action 'clickWithdraw'}}> {{t "submit.body.edit.withdraw_button" documentType=currentProvider.documentType}} </button>
+                                    {{/if}}
+                                {{/if}}
+                            </div>
+                        {{else}}
+                            <strong><p class="information">{{t permissionInformation documentType=currentProvider.documentType name=providerName}}</p></strong>
+                            {{#if moderationType}}
+                                <p class="information">
+                                    {{t moderationInformation documentType=currentProvider.documentType name=providerName reviewsWorkflow=(t workflow)}}
                                 </p>
+                            {{else}}
+                                <p class="information">{{t generalInformation documentType=currentProvider.documentType name=providerName}}</p>
                             {{/if}}
-                            {{#if canResubmit}}
-                                <button class="btn btn-success btn-md m-t-md pull-right" disabled={{unless allSectionsValid true}} {{action 'clickSubmit'}}>
-                                    {{t "submit.body.edit.resubmit_button"}}
+                            <div class="text-center">
+                                {{#if showValidationErrors}}
+                                    <span id="validation-errors">
+                                        <p class="m-t-md"><strong>{{t "submit.body.submit.invalid.description" documentType=currentProvider.documentType}}</strong></p>
+                                        <p class="text-danger">{{if (not (and savedTitle savedFile)) (t "submit.body.submit.invalid.upload")}}</p>
+                                        <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
+                                        <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
+                                        <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
+                                    </span>
+                                {{/if}}
+                                <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>
+                                    {{t buttonLabel documentType=currentProvider.documentType}}
+                                </button>
+                                <button class="btn btn-default btn-md m-t-md pull-right" {{action 'cancel'}}>
+                                    {{t "global.cancel"}}
                                 </button>
                                 <div>
                                     {{confirm-share-preprint
                                         isOpen=showModalSharePreprint
                                         shareButtonDisabled=shareButtonDisabled
-                                        savePreprint=(action 'resubmit')
-                                        buttonLabel="submit.body.edit.resubmit_button"
+                                        savePreprint=(action 'savePreprint')
+                                        buttonLabel=buttonLabel
                                         title=modalTitle
                                         documentType=currentProvider.documentType
                                     }}
                                 </div>
-                            {{/if}}
-
-                            {{#if (not (eq model.reviewsState 'rejected'))}}
-                                {{!-- Only shows the 'Withdraw preprint' button iff the preprint is not in a rejected state --}}
-                                <button class="btn {{if canResubmit 'btn-default' 'btn-danger'}} btn-md m-t-md pull-right" {{action 'clickWithdraw'}}> {{t "submit.body.edit.withdraw_button" documentType=currentProvider.documentType}} </button>
-                            {{/if}}
-                        </div>
-                    {{else}}
-                        <strong><p class="information">{{t permissionInformation documentType=currentProvider.documentType name=providerName}}</p></strong>
-                        {{#if moderationType}}
-                            <p class="information">
-                                {{t moderationInformation documentType=currentProvider.documentType name=providerName reviewsWorkflow=(t workflow)}}
-                            </p>
-                        {{else}}
-                            <p class="information">{{t generalInformation documentType=currentProvider.documentType name=providerName}}</p>
-                        {{/if}}
-                        <div class="text-center">
-                            {{#if showValidationErrors}}
-                                <span id="validation-errors">
-                                    <p class="m-t-md"><strong>{{t "submit.body.submit.invalid.description" documentType=currentProvider.documentType}}</strong></p>
-                                    <p class="text-danger">{{if (not (and savedTitle savedFile)) (t "submit.body.submit.invalid.upload")}}</p>
-                                    <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
-                                    <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
-                                    <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
-                                </span>
-                            {{/if}}
-                            <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>
-                                {{t buttonLabel documentType=currentProvider.documentType}}
-                            </button>
-                            <button class="btn btn-default btn-md m-t-md pull-right" {{action 'cancel'}}>
-                                {{t "global.cancel"}}
-                            </button>
-                            <div>
-                                {{confirm-share-preprint
-                                    isOpen=showModalSharePreprint
-                                    shareButtonDisabled=shareButtonDisabled
-                                    savePreprint=(action 'savePreprint')
-                                    buttonLabel=buttonLabel
-                                    title=modalTitle
-                                    documentType=currentProvider.documentType
-                                }}
                             </div>
-                        </div>
+                        {{/if}}
                     {{/if}}
                 </div>
             </div>


### PR DESCRIPTION
## Purpose

This PR fixes some small bugs on Preprints app and makes some text and button changes:
- On preprint edit/submit page, the bottom buttons only appears after the provider finishes loading.
- Change text for withdraw view notices.
- Change tombstone page banner text.
- Move "Return to preprint" link on top left of edit page back to bottom as a button.
- For a preprint, non-admin contributors should not be able to see withdraw button on edit page.

## Ticket

https://openscience.atlassian.net/browse/EMB-548

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
