### PR TITLE
[ENG-101] fix linebreaks and extra spaces in author list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.124.2] - 2019-04-08
+### Fixed
+- make sure there are no line breaks or extra spaces in author list
+
+## [0.124.1] - 2019-03-19
+### Changed
+- update assets
+
 ## [0.124.0] - 2019-03-04
 ### Removed
 - Remove margin hack to fix navbar on smaller screens

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -40,6 +40,9 @@ ul.comma-list {
     li:last-child:after {
         content: "";
     }
+    li div.unclaimed-user-modal {
+        display: inline;
+    }
     span:hover {
         background: gray;
     }

--- a/app/templates/components/claim-user.hbs
+++ b/app/templates/components/claim-user.hbs
@@ -1,11 +1,11 @@
 {{! template-lint-disable no-nested-interactive }}
-{{#if isLoggedIn}}
+{{~#if isLoggedIn~}}
     <span role="button" {{action 'toggleModal'}}>
-        {{author.unregisteredContributor}}
-        {{#bs-tooltip}}{{t 'components.claim-user.tooltip_message'}}{{/bs-tooltip}}
+        {{~author.unregisteredContributor~}}
+        {{~#bs-tooltip}}{{t 'components.claim-user.tooltip_message'}}{{/bs-tooltip~}}
     </span>
-    {{#if (not getUserEmail.isRunning)}}
-        {{#bs-modal backdrop=true open=showModal onHide=(action 'toggleModal') as |modal|}}
+    {{~#if (not getUserEmail.isRunning)~}}
+        {{#bs-modal class='unclaimed-user-modal' backdrop=true open=showModal onHide=(action 'toggleModal') as |modal|}}
             {{#modal.header}}
                 <h3>{{t 'components.claim-user.modal_title' email=username}}</h3>
             {{/modal.header}}
@@ -17,12 +17,12 @@
                 {{#bs-button onClick=(perform claimUser) type='primary'}}{{t 'components.claim-user.claim_button'}}{{/bs-button}}
             {{/modal.footer}}
         {{/bs-modal}}
-    {{/if}}
-{{else}}
+    {{~/if~}}
+{{~else~}}
     <span role="button" {{action 'togglePopup'}}>
-        {{author.unregisteredContributor}}
-        {{#bs-tooltip}}{{t 'components.claim-user.tooltip_message'}}{{/bs-tooltip}}
-        {{#bs-popover placement='bottom' title=(t 'components.claim-user.title') visible=showPopup}}
+        {{~author.unregisteredContributor~}}
+        {{~#bs-tooltip}}{{t 'components.claim-user.tooltip_message'}}{{/bs-tooltip~}}
+        {{~#bs-popover placement='bottom' title=(t 'components.claim-user.title') visible=showPopup}}
             {{#click-outside action=(action 'hidePopup') }}
                 <div style="display: flex">
                     {{validated-input model=this valuePath='email' placeholder=(t "components.unregistered-contributor-form.email") value=email}}
@@ -30,7 +30,7 @@
                     <button type="button" class="btn btn-default btn-small popover-button" {{action 'togglePopup'}}> {{t "global.cancel"}} </button>
                 </div>
             {{/click-outside}}
-        {{/bs-popover}}
+        {{/bs-popover~}}
     </span>
-{{/if}}
+{{~/if~}}
 {{! template-lint-enable no-nested-interactive }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprint-service",
-  "version": "0.124.0",
+  "version": "0.124.2",
   "description": "Center for Open Science Preprint Service",
   "license": "Apache-2.0",
   "author": "",


### PR DESCRIPTION
## Purpose

The author list will contain line breaks after unregistered users when logged in and spaces before the comma when logged out.

## Summary of Changes/Side Effects

* display wrapper div for bs-modal for claim use confirmation as inline 
* add `~`s to eat up spaces and line breaks inside the `li`
* removed newline at end of `claim-user` template

## Testing Notes

Make sure author lists render correctly when an unregistered user appears in the middle of the list when logged in and when logged out.

## Ticket

https://openscience.atlassian.net/browse/ENG-101

## Notes for Reviewer

Styling the bs-modal wrapper div does not affect the modal that is rendered in the wormhole.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
