### PR TITLE
[ENG-560] make preprint withdrawal request explanation required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- make preprint withdrawal request explanation required
 
 ## [0.125.3] - 2019-06-06
 ### Changed

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -292,7 +292,7 @@ export default {
     },
     withdraw: {
         heading: 'Withdraw {{documentType.singularCapitalized}}',
-        withdrawal_form_heading: 'Reason for withdrawal (optional):',
+        withdrawal_form_heading: 'Reason for withdrawal (required):',
         pre_moderation_notice_pending: 'Your {{documentType.singular}} is still pending approval and thus private, but can be withdrawn immediately. If you wish to provide a reason for withdrawal, it will be displayed only to service moderators. Once withdrawn, your preprint will never be made public.',
         pre_moderation_notice_accepted: 'This service uses pre-moderation. Your {{documentType.singular}} withdrawal must be approved by a moderator. Once approved, your {{documentType.singular}} will be removed, but basic metadata (like title, authors, and reason for withdrawal, if provided) will remain.',
         post_moderation_notice: 'This service uses post-moderation. Because of that, your request will need to be approved by a moderation administrator before your {{documentType.singular}} can be withdrawn. If you request is approved, your {{documentType.singular}} will be replaced with a tombstone page with metadata and the reason for withdrawal (if included). Your {{documentType.singular}} will still be searchable by other users.',

--- a/app/templates/content/withdraw.hbs
+++ b/app/templates/content/withdraw.hbs
@@ -17,7 +17,7 @@
                     <header>
                         {{ t 'withdraw.withdrawal_form_heading' }}
                     </header>
-                    {{textarea value=explanation class="form-control"}}
+                    {{validated-input inputType='textarea' model=this valuePath='explanation' value=explanation showErrorMessage=didValidate}}
                 </section>
 
                 <div class="submit-section">


### PR DESCRIPTION
## Purpose

Make preprint withdrawal request explanation required.

## Summary of Changes/Side Effects

Before:
![Screen Shot 2019-06-12 at 2 29 16 PM](https://user-images.githubusercontent.com/348630/59376684-9895cc00-8d1e-11e9-91f9-140cb5a4b15a.png)

After:
![Screen Shot 2019-06-12 at 2 24 50 PM](https://user-images.githubusercontent.com/348630/59376899-0e9a3300-8d1f-11e9-8edb-a1c38f0433a8.png)
![Screen Shot 2019-06-12 at 2 25 05 PM](https://user-images.githubusercontent.com/348630/59376882-03df9e00-8d1f-11e9-83c6-3d1bcbcf90c6.png)
![Screen Shot 2019-06-12 at 2 25 19 PM](https://user-images.githubusercontent.com/348630/59376859-f7f3dc00-8d1e-11e9-946e-5ac0dd72786c.png)
![Screen Shot 2019-06-12 at 2 25 49 PM](https://user-images.githubusercontent.com/348630/59376849-f0ccce00-8d1e-11e9-9a65-1f7f53f59335.png)


## Testing Notes

Need to test that a withdrawal request cannot be made without providing a reason that is at least 25 characters long.

## Ticket

https://openscience.atlassian.net/browse/ENG-560

## Notes for Reviewer

I've overridden `showErrorMessage` (by passing in `didValidate`) on the `validated-input` to ensure the error message is not shown until the "Request withdrawal" button has been pressed.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
