### PR TITLE
[ENG-586] Only show chronos submission link to submitter

### DIFF
--- a/app/components/chronos-submission-status-list-row/template.hbs
+++ b/app/components/chronos-submission-status-list-row/template.hbs
@@ -1,6 +1,6 @@
 <div>
     {{fa-icon statusIcon class=statusIconClass}} {{statusLanguage}}
-    {{#if isContributor}}
+    {{#if submission.submissionUrl}}
         <a target="_blank" rel="noopener" class="fa fa-external-link" href={{submission.submissionUrl}}></a>
     {{/if}}
 </div>


### PR DESCRIPTION
## Purpose

Only show link if the link is returned from the API.

## Testing Notes

The link button should now show only if the user is a submitter of this chronos submission.

## Ticket

https://openscience.atlassian.net/browse/ENG-586

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
