### PR TITLE
[ENG-37] [ENG-1219] Enable uploading of a preprint with different name and extension

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -57,7 +57,6 @@ export default Component.extend(Analytics, {
     toast: service(),
     fileManager: service(),
     panelActions: service('panelActions'),
-    currentUser: service('current-user'),
     model: null,
     // If file added successfully (add mode), id saved here.  Used
     // for avoiding 409's
@@ -214,12 +213,9 @@ export default Component.extend(Analytics, {
         preUpload(_, dropzone, file) {
             // preUpload or "stage" file. Has yet to be uploaded to preprint.
             this.set('uploadInProgress', false);
-            if (this.get('preprintLocked')) { // Edit mode
-                // if (file.name !== this.get('osfFile.name')) { // Invalid File - throw error.
-                //     this.send('mustModifyCurrentPreprintFile');
-                // } else { // Valid file - can be staged.
+            if (this.get('preprintLocked')) {
+                // Edit mode
                 this.send('setPreUploadedFileAttributes', file, this.get('osfFile.currentVersion') + 1);
-                // }
             } else { // Add mode
                 this.attrs.clearDownstreamFields('belowFile');
                 this.send('setPreUploadedFileAttributes', file, this.get('osfFile.currentVersion'));
@@ -380,8 +376,6 @@ export default Component.extend(Analytics, {
         this.get('toast').error(this.get('i18n').t('components.file-uploader.could_not_update_title'));
     },
     _renameFileAfterSuccessfulUpload() {
-        console.log(this.get('newFileName'));
-        console.log(this.get('osfFile'));
         this.get('fileManager').rename(this.get('osfFile'), this.get('newFileName'));
     },
 });

--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -222,11 +222,6 @@ export default Component.extend(Analytics, {
             }
             this.send('preUploadMetrics');
             this.set('callback', defer());
-            // Delays so user can see that file has been preuploaded before
-            // advancing to next panel
-            later(() => {
-                this.attrs.nextUploadSection('uploadNewFile', 'finalizeUpload');
-            }, 1500);
             return this.get('callback.promise');
         },
         discardUploadChanges() {

--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { later } from '@ember/runloop';
 import { defer } from 'rsvp';
 import $ from 'jquery';
 import Analytics from 'ember-osf/mixins/analytics';
@@ -370,6 +369,7 @@ export default Component.extend(Analytics, {
         this.set('uploadInProgress', false);
         this.get('toast').error(this.get('i18n').t('components.file-uploader.could_not_update_title'));
     },
+
     _renameFileAfterSuccessfulUpload() {
         this.get('fileManager').rename(this.get('osfFile'), this.get('newFileName'));
     },

--- a/app/components/preprint-file-renderer.js
+++ b/app/components/preprint-file-renderer.js
@@ -71,13 +71,13 @@ export default Component.extend(Analytics, {
             `download/${primaryFileGuid}`,
             `${primaryFileGuid}/download`,
         );
-        const filename = this.get('primaryFile.name');
+
         this.set('primaryFileHasVersions', versions.length > 1);
 
         return versions
             .map((version) => {
                 const dateFormatted = encodeURIComponent(version.get('dateCreated').toISOString());
-                const displayName = filename.replace(/(\.\w+)?$/, ext => `-${dateFormatted}${ext}`);
+                const displayName = version.get('name').replace(/(\.\w+)?$/, ext => `-${dateFormatted}${ext}`);
                 version.set('downloadUrl', `${directDownloadUrl}?version=${version.id}&displayName=${displayName}`);
                 return version;
             });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hotfix": "git flow hotfix start rename-me && npm --no-git-tag-version version patch && git ci package.json -m 'Bump version' && git br -m \"hotfix/$(npm version | head -1 | grep -o '[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+')\""
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#0.26.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-10-25T14:36:53Z",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "autoprefixer": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,9 +183,9 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#0.26.0":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2019-10-25T14:36:53Z":
   version "0.26.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2f413320921bbecf77cd8241c458ddfef55ed6fe"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#9abf7955d4ac22d2c4971c2c8fd52a80acddf2e2"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose

Remove the constraint on the preprint app where users cannot upload another version of preprint file with different filename.
Also modify the `file-uploader` to change the filename after the upload is successful.


## Testing Notes
Make sure that the new version of files is properly rendered by MFR.

## Ticket

[ENG-37]
[ENG-1219]

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->


[ENG-37]: https://openscience.atlassian.net/browse/ENG-37

[ENG-1219]: https://openscience.atlassian.net/browse/ENG-1219