### PR TITLE
[ENG-882] Add plaudit widget and use it after meta tags are ready

### DIFF
--- a/app/components/plaudit-widget/component.js
+++ b/app/components/plaudit-widget/component.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
-import { inject as service } from '@ember/service';
-import config from 'ember-get-config'
+import config from 'ember-get-config';
 
 export default Component.extend({
     plauditWidgetUrl: config.plauditWidgetUrl,

--- a/app/components/plaudit-widget/component.js
+++ b/app/components/plaudit-widget/component.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import config from 'ember-get-config'
+
+export default Component.extend({
+    plauditWidgetUrl: config.plauditWidgetUrl,
+});

--- a/app/components/plaudit-widget/template.hbs
+++ b/app/components/plaudit-widget/template.hbs
@@ -1,0 +1,4 @@
+<script async 
+    src={{plauditWidgetUrl}}
+    data-embedder-id="osf_preprints">
+</script>

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -54,6 +54,7 @@ export default Controller.extend(Analytics, {
     isPendingWithdrawal: false,
     isWithdrawn: null,
     expandedAbstract: navigator.userAgent.includes('Prerender'),
+    isPlauditReady: false,
 
     hasTag: computed.bool('model.tags.length'),
     relevantDate: computed.alias('model.dateCreated'),

--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -53,8 +53,8 @@ export default Controller.extend(Analytics, {
     showModalClaimUser: false,
     isPendingWithdrawal: false,
     isWithdrawn: null,
-    expandedAbstract: navigator.userAgent.includes('Prerender'),
     isPlauditReady: false,
+    expandedAbstract: navigator.userAgent.includes('Prerender'),
 
     hasTag: computed.bool('model.tags.length'),
     relevantDate: computed.alias('model.dateCreated'),

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -314,7 +314,8 @@ export default Route.extend(Analytics, ResetScrollMixin, {
         this.set('headTags', headTags);
         this.get('headTagsService').collectHeadTags();
         run.scheduleOnce('afterRender', this, function() {
-            this.controller.set('isPlauditReady', true);
+            const controller = this.controllerFor('content.index');
+            controller.set('isPlauditReady', true);
         });
     },
 });

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -45,6 +45,7 @@ export default Route.extend(Analytics, ResetScrollMixin, {
     waitForMetaData: navigator.userAgent.includes('Prerender'),
     contributors: A(),
 
+
     afterModel(preprint) {
         const { location: { origin } } = window;
 
@@ -312,6 +313,8 @@ export default Route.extend(Analytics, ResetScrollMixin, {
 
         this.set('headTags', headTags);
         this.get('headTagsService').collectHeadTags();
-        this.controller.set('isPlauditReady', true);
+        run.scheduleOnce('afterRender', this, function() {
+            this.controller.set('isPlauditReady', true);
+        });
     },
 });

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -312,5 +312,6 @@ export default Route.extend(Analytics, ResetScrollMixin, {
 
         this.set('headTags', headTags);
         this.get('headTagsService').collectHeadTags();
+        this.controller.set('isPlauditReady', true);
     },
 });

--- a/app/styles/preprint-detail-page.scss
+++ b/app/styles/preprint-detail-page.scss
@@ -16,3 +16,18 @@
         width: 150px;
     }
 }
+
+.flexbox {
+    justify-content: flex-end;
+    display: flex;
+    align-items: center;
+}
+
+.social-icons {
+    padding: 15px 0px 15px 0px;
+}
+
+.plaudit-widget {
+    flex: auto;
+    padding-right: 33px;
+}

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -125,8 +125,13 @@
                             <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
                             <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
                         </div>
-                        <div class="clearfix">
-                            <div class="p-t-md pull-right">
+                        <div class="flexbox">
+                            <div class="plaudit-widget">
+                                {{#if isPlauditReady}}
+                                    {{plaudit-widget}}
+                                {{/if}}
+                            </div>
+                            <div class="social-icons">
                                 {{sharing-icons
                                     title=title
                                     description=fullDescription
@@ -305,7 +310,4 @@
         {{/if}}
     </div>
     {{!END DIV CONTAINER}}
-    {{#if isPlauditReady}}
-        {{plaudit-widget}}
-    {{/if}}
 </div>

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -305,4 +305,7 @@
         {{/if}}
     </div>
     {{!END DIV CONTAINER}}
+    {{#if isPlauditReady}}
+        {{plaudit-widget}}
+    {{/if}}
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -105,6 +105,7 @@ module.exports = function(environment) {
             '2160-4134',
             '1196-1961',
         ],
+        plauditWidgetUrl: 'https://osf-review.plaudit.pub/embed/endorsements.js',
     };
 
     if (environment === 'development') {


### PR DESCRIPTION
## Purpose

Add plaudit widget and only render it after meta tags are ready.

## Testing Notes
Make sure the plaudit widget shows up at the bottom when the preprint has a doi.

## Ticket

https://openscience.atlassian.net/browse/ENG-882

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
