### PR TITLE
[ENG-1269][Feature] Add 'beta' to Chronos submission link

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -341,7 +341,7 @@ export default {
             published: 'Published in <i>{{title}}</i>',
         },
         'chronos-submission-panel': {
-            link_text: 'Submit to an APA-published journal',
+            link_text: 'Submit to an APA-published journal (beta)',
             helper_text: 'A new tab will open to complete submission on Chronos.',
         },
         'error-page': {


### PR DESCRIPTION
## Purpose
To make it clear to initial users that the Chronos feature is a beta.


## Summary of Changes/Side Effects
- Added `(beta)` to the translation


## Testing Notes
This will only add the `(beta)` to the end of the Chronos submission link.


## Ticket

https://openscience.atlassian.net/browse/ENG-1269

## Notes for Reviewer
N/A

## Additional Notes
This will need to be reversed when Chronos is waffled on for everyone.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
