### PR TITLE
[ENG-508] Remove upload bar unless the file is being uploaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- remove the upload bar on preprints submission unless the file is in the process of being uploaded
 
 ## [0.129.0] - 2019-11-04
 - add Plaudit widget and use on overview page after meta tags are ready

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -611,8 +611,10 @@ $color-border-light: #DDDDDD;
         margin-top: 10px;
         text-align: center;
     }
+
     .dz-progress {
-        z-index : 10;
+        z-index: 10;
+        display: none !important;
     }
 
     .dropzone.dz-started .dz-message {
@@ -629,6 +631,12 @@ $color-border-light: #DDDDDD;
     .radio-option {
         background: #f5f5f5;
         border-radius: 2px;
+    }
+}
+
+.preprint-form-upload.upload-in-progress {
+    .dz-progress {
+        display: block !important;
     }
 }
 .file-browser-header {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -612,9 +612,9 @@ $color-border-light: #DDDDDD;
         text-align: center;
     }
 
-    .dz-progress {
+    .dropzone .dz-progress {
         z-index: 10;
-        display: none !important;
+        display: none;
     }
 
     .dropzone.dz-started .dz-message {
@@ -635,10 +635,11 @@ $color-border-light: #DDDDDD;
 }
 
 .preprint-form-upload.upload-in-progress {
-    .dz-progress {
-        display: block !important;
+    .dropzone .dz-progress {
+        display: block;
     }
 }
+
 .file-browser-header {
     display: none;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -617,6 +617,10 @@ $color-border-light: #DDDDDD;
         display: none;
     }
 
+    &.upload-in-progress .dropzone .dz-progress {
+        display: block;
+    }
+
     .dropzone.dz-started .dz-message {
         opacity: 1; // Override default to keep from disappearing
         margin-top: 0;
@@ -631,12 +635,6 @@ $color-border-light: #DDDDDD;
     .radio-option {
         background: #f5f5f5;
         border-radius: 2px;
-    }
-}
-
-.preprint-form-upload.upload-in-progress {
-    .dropzone .dz-progress {
-        display: block;
     }
 }
 

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -54,7 +54,7 @@
                     {{#with _names.[1] as |name|}}
                         {{#preprint-form-section
                             editMode=editMode
-                            class="preprint-form-upload"
+                            class=(if uploadInProgress "preprint-form-upload upload-in-progress" "preprint-form-upload")
                             name=name
                             allowOpen=(or providerSaved editMode)
                             open=(and theme.isProvider (not editMode))

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -54,7 +54,7 @@
                     {{#with _names.[1] as |name|}}
                         {{#preprint-form-section
                             editMode=editMode
-                            class=(if uploadInProgress "preprint-form-upload upload-in-progress" "preprint-form-upload")
+                            class=(concat 'preprint-form-upload' (if uploadInProgress ' upload-in-progress'))
                             name=name
                             allowOpen=(or providerSaved editMode)
                             open=(and theme.isProvider (not editMode))


### PR DESCRIPTION
## Purpose
Having the upload bar displayed on preprints submission is confusing to users, since it looks like the file is having issues being uploaded.  This PR will remove the upload bar until the user clicks "save" and the file is actually in the process of being uploaded.


## Summary of Changes/Side Effects
- Added styling to dropzone classes to hide/show the upload bar
- Added conditional class in the `submit` template for styling when uploading

<img width="708" alt="Screen Shot 2019-12-13 at 11 32 52 AM" src="https://user-images.githubusercontent.com/19379783/70817036-afd17700-1d9e-11ea-8f1e-8a644a0d6eb4.png">


## Testing Notes
- This should only affect when the user is uploading a new file on the submit/edit pages, but should be tested in all cases when a user tries to submit a new file in preprints


## Ticket

https://openscience.atlassian.net/browse/ENG-508

## Notes for Reviewer


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
