### PR TITLE
[ENG-1435] Placeholder for new sections in submission workflow

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -235,9 +235,9 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     originalPublicationDateValid: alias('validations.attrs.basicsOriginalPublicationDate.isValid'),
 
     // Sloan waffles
-    sloanCoiDisplayEnabled: alias('features.sloanCoiDisplay'),
-    sloanDataDisplayEnabled: alias('features.sloanDataDisplay'),
-    sloanPreregDisplayEnabled: alias('features.sloanPreregDisplay'),
+    sloanCoiInputEnabled: alias('features.sloanCoiInput'),
+    sloanDataInputEnabled: alias('features.sloanDataInput'),
+    sloanPreregInputEnabled: alias('features.sloanPreregInput'),
 
     // Basics fields that are being validated are abstract, license and doi
     // (title validated in upload section). If validation

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -219,7 +219,7 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     // Must have year and copyrightHolders filled if those are required by the licenseType selected
     licenseValid: false,
 
-    _names: ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'], // Form section headers
+    _names: ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'], // Form section headers
     hasFile: computed.or('file', 'selectedFile'),
     isAddingPreprint: computed.not('editMode'),
     // Contributors on preprint

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -138,6 +138,7 @@ function subjectIdMap(subjectArray) {
  * @class Submit Controller
  */
 export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin, TaggableMixin, {
+    features: service(),
     i18n: service(),
     store: service(),
     theme: service(),
@@ -232,6 +233,11 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
 
     doiValid: alias('validations.attrs.basicsDOI.isValid'),
     originalPublicationDateValid: alias('validations.attrs.basicsOriginalPublicationDate.isValid'),
+
+    // Sloan waffles
+    sloanCoiDisplayEnabled: alias('features.sloanCoiDisplay'),
+    sloanDataDisplayEnabled: alias('features.sloanDataDisplay'),
+    sloanPreregDisplayEnabled: alias('features.sloanPreregDisplay'),
 
     // Basics fields that are being validated are abstract, license and doi
     // (title validated in upload section). If validation

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -220,6 +220,32 @@ export default {
             authors: {
                 paragraph: 'Add {{documentType.singular}} authors and order them appropriately. Search for authors that have OSF accounts or invite unregistered users to join by entering their email addresses.',
             },
+            author_assertions: {
+                public_data: {
+                    label: 'Public Data',
+                    placeholder: 'Author asserted there is no data associated with this work.',
+                    description: 'Data refers to raw and/or processed information (quantitative or qualitative) used for the analyses, case studies, and/or descriptive interpretation in the <preprint_word>. Public data could include data posted to open-access repositories, public archival library collection, or government archive. For data that is available under limited circumstances (e.g., after signing a data sharing agreement), choose the ‘No’ option and use the comment box to explain how others could access the data.',
+                },
+                preregistration: {
+                    label: 'Preregistration',
+                    placeholder: 'Author asserted no data was collected, extracted, or analyzed.',
+                    description: 'A preregistration is a description of the research design and/or analysis plan that is created and registered before researchers collected data or before they have seen/interacted with preexisting data. The description should appear in a public registry (e.g., clinicaltrials.gov, OSF, AEA registry).',
+                },
+            },
+            conflict_of_interest: {
+                label: 'Conflict of Interest',
+                placeholder: 'Author asserted no Conflict of Interest.',
+                description: 'The Conflict of Interest (COI) assertion is made on behalf of all the authors listed for this {{documentType.singular}}. COI’s include: financial involvement in any entity such as honoraria, grants, speaking fees, employment, consultancies, stock ownership, expert testimony, and patents or licenses. COI’s can also include non-financial interests such as personal or professional relationships or pre-existing beliefs in the subject matter or materials discussed in this {{documentType.singular}}',
+            },
+            general: {
+                required: '(required)',
+                yes: 'Yes',
+                no: 'No',
+                not_applicable: 'Not applicable',
+                available: 'Available',
+                describe: 'Describe',
+                links_to_data: 'Links to data',
+            },
             submit: {
                 information: {
                     line1: {
@@ -417,12 +443,14 @@ export default {
             name: {
                 Server: 'Select a service',
                 File: 'File',
+                Assertions: 'Author Assertions',
                 Discipline: 'Discipline',
                 Basics: 'Basics',
                 Authors: 'Authors',
                 Submit: 'Submit',
                 Update: 'Update',
                 Supplemental: 'Supplemental materials',
+                COI: 'Conflicts of Interest',
                 choose_project: 'Choose Project',
                 choose_file: 'Choose File',
                 organize: 'Organize',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -220,32 +220,6 @@ export default {
             authors: {
                 paragraph: 'Add {{documentType.singular}} authors and order them appropriately. Search for authors that have OSF accounts or invite unregistered users to join by entering their email addresses.',
             },
-            author_assertions: {
-                public_data: {
-                    label: 'Public Data',
-                    placeholder: 'Author asserted there is no data associated with this work.',
-                    description: 'Data refers to raw and/or processed information (quantitative or qualitative) used for the analyses, case studies, and/or descriptive interpretation in the <preprint_word>. Public data could include data posted to open-access repositories, public archival library collection, or government archive. For data that is available under limited circumstances (e.g., after signing a data sharing agreement), choose the ‘No’ option and use the comment box to explain how others could access the data.',
-                },
-                preregistration: {
-                    label: 'Preregistration',
-                    placeholder: 'Author asserted no data was collected, extracted, or analyzed.',
-                    description: 'A preregistration is a description of the research design and/or analysis plan that is created and registered before researchers collected data or before they have seen/interacted with preexisting data. The description should appear in a public registry (e.g., clinicaltrials.gov, OSF, AEA registry).',
-                },
-            },
-            conflict_of_interest: {
-                label: 'Conflict of Interest',
-                placeholder: 'Author asserted no Conflict of Interest.',
-                description: 'The Conflict of Interest (COI) assertion is made on behalf of all the authors listed for this {{documentType.singular}}. COI’s include: financial involvement in any entity such as honoraria, grants, speaking fees, employment, consultancies, stock ownership, expert testimony, and patents or licenses. COI’s can also include non-financial interests such as personal or professional relationships or pre-existing beliefs in the subject matter or materials discussed in this {{documentType.singular}}',
-            },
-            general: {
-                required: '(required)',
-                yes: 'Yes',
-                no: 'No',
-                not_applicable: 'Not applicable',
-                available: 'Available',
-                describe: 'Describe',
-                links_to_data: 'Links to data',
-            },
             submit: {
                 information: {
                     line1: {
@@ -443,14 +417,12 @@ export default {
             name: {
                 Server: 'Select a service',
                 File: 'File',
-                Assertions: 'Author Assertions',
                 Discipline: 'Discipline',
                 Basics: 'Basics',
                 Authors: 'Authors',
                 Submit: 'Submit',
                 Update: 'Update',
                 Supplemental: 'Supplemental materials',
-                COI: 'Conflicts of Interest',
                 choose_project: 'Choose Project',
                 choose_file: 'Choose File',
                 organize: 'Organize',

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -136,8 +136,8 @@
                     {{/with}}
 
                     {{! ===== AUTHOR ASSERTIONS HERE ===== }}
-                    {{#if (or sloanDataDisplayEnabled sloanPreregDisplayEnabled)}}
-                        {{#with _names.[2] as |name|}}
+                    {{!-- {{#if (or sloanDataDisplayEnabled sloanPreregDisplayEnabled)}}
+                        {{#with _names.[2] as |name|}} --}}
                             {{!-- Add logic for Data availability here --}}
                             {{!-- No: Optional textarea
                                   NA: Disabled Textbox with placeholder
@@ -151,8 +151,8 @@
                                   Available: required multiple textbox for links, dropdown to denote type 
                             --}}
                             {{!-- Section explaining Prereg here --}}
-                        {{/with}}
-                    {{/if}}
+                        {{!-- {{/with}}
+                    {{/if}} --}}
 
                     {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -254,15 +254,15 @@
                     {{/with}}
 
                     {{! ==== COI HERE ==== }}
-                    {{#if sloanCoiDisplayEnabled}}
-                        {{#with _names.[6] as |name|}}
+                    {{!-- {{#if sloanCoiDisplayEnabled}}
+                        {{#with _names.[6] as |name|}} --}}
                             {{!-- Add logic for COI here --}}
                             {{!-- No: Disabled Textbox with placeholder
                                   Yes: Required textarea to describe
                             --}}
                             {{!-- Section explaining COI here --}}
-                        {{/with}}
-                    {{/if}}
+                        {{!-- {{/with}}
+                    {{/if}} --}}
 
                     {{#with _names.[7] as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -136,22 +136,23 @@
                     {{/with}}
 
                     {{! ===== AUTHOR ASSERTIONS HERE ===== }}
-                    {{#with _names.[2] as |name|}}
-                        {{#preprint-form-section id='preprint-form-author-assertions' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode doi=model.doi tags=model.tags name=name license=model.license isValidationActive=hasOpened}}
-                            {{#preprint-form-body}}
-                                <label>{{t "submit.body.author_assertions.public_data.label"}}:</label>
-                                <input type="radio" name="data" value="No"> {{t "submit.body.general.no"}}
-                                <input type="radio" name="data" value="NA"> {{t "submit.body.general.not_applicable"}}
-                                <input type="radio" name="data" value="Available"> {{t "submit.body.general.available"}}
-                                
-                                <label>{{t "submit.body.author_assertions.preregistration.label"}}:</label>
-                                <input type="radio" name="preregistration" value="No"> {{t "submit.body.general.no"}}
-                                <input type="radio" name="preregistration" value="NA"> {{t "submit.body.general.not_applicable"}}
-                                <input type="radio" name="preregistration" value="Available"> {{t "submit.body.general.available"}}
-                            {{/preprint-form-body}}
-                        {{/preprint-form-section}}
-                    {{/with}}
+                    {{#if (or sloanDataDisplayEnabled sloanPreregDisplayEnabled)}}
+                        {{#with _names.[2] as |name|}}
+                            {{!-- Add logic for Data availability here --}}
+                            {{!-- No: Optional textarea
+                                  NA: Disabled Textbox with placeholder
+                                  Available: required multiple textbox for links 
+                            --}}
+                            {{!-- Section explaining Data Avaliability here --}}
+
+                            {{!-- Add logic for Prereg here --}}
+                            {{!-- No: Optional textarea
+                                  NA: Disabled Textbox with placeholder
+                                  Available: required multiple textbox for links, dropdown to denote type 
+                            --}}
+                            {{!-- Section explaining Prereg here --}}
+                        {{/with}}
+                    {{/if}}
 
                     {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -253,14 +254,16 @@
                     {{/with}}
 
                     {{! ==== COI HERE ==== }}
-                    {{#with _names.[6] as |name|}}
-                        {{#preprint-form-section id="author-assertions" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode supplementalSaveState=supplementalSaveState supplementalProjectTitle=supplementalProjectTitle node=node name=name valid=(not supplementalChanged) isValidationActive=hasOpened}}
-                            {{#preprint-form-body}}
-                                {{! TODO: add content here}}
-                            {{/preprint-form-body}}
-                        {{/preprint-form-section}}
-                    {{/with}}
+                    {{#if sloanCoiDisplayEnabled}}
+                        {{#with _names.[6] as |name|}}
+                            {{!-- Add logic for COI here --}}
+                            {{!-- No: Disabled Textbox with placeholder
+                                  Yes: Required textarea to describe
+                            --}}
+                            {{!-- Section explaining COI here --}}
+                        {{/with}}
+                    {{/if}}
+
                     {{#with _names.[7] as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode supplementalSaveState=supplementalSaveState supplementalProjectTitle=supplementalProjectTitle node=node name=name valid=(not supplementalChanged) isValidationActive=hasOpened}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -135,7 +135,25 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
+                    {{! ===== AUTHOR ASSERTIONS HERE ===== }}
                     {{#with _names.[2] as |name|}}
+                        {{#preprint-form-section id='preprint-form-author-assertions' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header editMode=editMode doi=model.doi tags=model.tags name=name license=model.license isValidationActive=hasOpened}}
+                            {{#preprint-form-body}}
+                                <label>{{t "submit.body.author_assertions.public_data.label"}}:</label>
+                                <input type="radio" name="data" value="No"> {{t "submit.body.general.no"}}
+                                <input type="radio" name="data" value="NA"> {{t "submit.body.general.not_applicable"}}
+                                <input type="radio" name="data" value="Available"> {{t "submit.body.general.available"}}
+                                
+                                <label>{{t "submit.body.author_assertions.preregistration.label"}}:</label>
+                                <input type="radio" name="preregistration" value="No"> {{t "submit.body.general.no"}}
+                                <input type="radio" name="preregistration" value="NA"> {{t "submit.body.general.not_applicable"}}
+                                <input type="radio" name="preregistration" value="Available"> {{t "submit.body.general.available"}}
+                            {{/preprint-form-body}}
+                        {{/preprint-form-section}}
+                    {{/with}}
+
+                    {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=model.tags abstract=model.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -186,7 +204,7 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#with _names.[3] as |name|}}
+                    {{#with _names.[4] as |name|}}
                         {{#preprint-form-section id='preprint-form-subjects' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode disciplineSaveState=disciplineSaveState subjects=disciplineReduced name=name valid=(not disciplineChanged) isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -204,7 +222,7 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#with _names.[4] as |name|}}
+                    {{#with _names.[5] as |name|}}
                         {{#preprint-form-section id='preprint-form-authors' editMode=editMode name=name allowOpen=uploadValid open=authorsOpen errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode authorsSaveState=authorsSaveState authors=contributors name=name valid=authorsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -233,7 +251,17 @@
                             {{/preprint-form-body}}
                         {{/preprint-form-section}}
                     {{/with}}
-                    {{#with _names.[5] as |name|}}
+
+                    {{! ==== COI HERE ==== }}
+                    {{#with _names.[6] as |name|}}
+                        {{#preprint-form-section id="author-assertions" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header editMode=editMode supplementalSaveState=supplementalSaveState supplementalProjectTitle=supplementalProjectTitle node=node name=name valid=(not supplementalChanged) isValidationActive=hasOpened}}
+                            {{#preprint-form-body}}
+                                {{! TODO: add content here}}
+                            {{/preprint-form-body}}
+                        {{/preprint-form-section}}
+                    {{/with}}
+                    {{#with _names.[7] as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode supplementalSaveState=supplementalSaveState supplementalProjectTitle=supplementalProjectTitle node=node name=name valid=(not supplementalChanged) isValidationActive=hasOpened}}
                             {{#preprint-form-body}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -136,23 +136,19 @@
                     {{/with}}
 
                     {{! ===== AUTHOR ASSERTIONS HERE ===== }}
-                    {{!-- {{#if (or sloanDataDisplayEnabled sloanPreregDisplayEnabled)}}
-                        {{#with _names.[2] as |name|}} --}}
-                            {{!-- Add logic for Data availability here --}}
-                            {{!-- No: Optional textarea
-                                  NA: Disabled Textbox with placeholder
-                                  Available: required multiple textbox for links 
-                            --}}
-                            {{!-- Section explaining Data Avaliability here --}}
+                    {{!-- Add logic for Data availability here --}}
+                    {{!-- No: Optional textarea
+                        NA: Disabled Textbox with placeholder
+                        Available: required multiple textbox for links
+                    --}}
+                    {{!-- Section explaining Data Avaliability here --}}
 
-                            {{!-- Add logic for Prereg here --}}
-                            {{!-- No: Optional textarea
-                                  NA: Disabled Textbox with placeholder
-                                  Available: required multiple textbox for links, dropdown to denote type 
-                            --}}
-                            {{!-- Section explaining Prereg here --}}
-                        {{!-- {{/with}}
-                    {{/if}} --}}
+                    {{!-- Add logic for Prereg here --}}
+                    {{!-- No: Optional textarea
+                        NA: Disabled Textbox with placeholder
+                        Available: required multiple textbox for links, dropdown to denote type
+                    --}}
+                    {{!-- Section explaining Prereg here --}}
 
                     {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -254,15 +250,11 @@
                     {{/with}}
 
                     {{! ==== COI HERE ==== }}
-                    {{!-- {{#if sloanCoiDisplayEnabled}}
-                        {{#with _names.[6] as |name|}} --}}
-                            {{!-- Add logic for COI here --}}
-                            {{!-- No: Disabled Textbox with placeholder
-                                  Yes: Required textarea to describe
-                            --}}
-                            {{!-- Section explaining COI here --}}
-                        {{!-- {{/with}}
-                    {{/if}} --}}
+                    {{!-- Add logic for COI here --}}
+                    {{!-- No: Disabled Textbox with placeholder
+                        Yes: Required textarea to describe
+                    --}}
+                    {{!-- Section explaining COI here --}}
 
                     {{#with _names.[7] as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -53,6 +53,7 @@ moduleFor('controller:submit', 'Unit | Controller | submit', {
         'service:theme',
         'service:toast',
         'service:i18n',
+        'service:features',
         'model:review-action',
         'model:file',
         'model:file-version',

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -99,7 +99,7 @@ test('Initial properties', function (assert) {
         '_State.EXISTING': 'existing',
         filePickerState: 'start',
         supplementalPickerState: 'start',
-        '_names.length': 6,
+        '_names.length': 8,
         user: null,
         'availableLicenses.length': 0,
         node: null,


### PR DESCRIPTION
## Purpose
Add placeholders to the preprint submission workflow for Sloan signals of trust

## Summary of Changes/Side Effects
- Added waffle flags to submission page for COI, data availability, and prereg
- Add waffled Author Assertions placeholder
- Add waffled COI placeholder

## Testing Notes
- This is just to add a sections to be filled out in later PRs, so this does not require testing

## Ticket
[ENG-1435]
https://openscience.atlassian.net/browse/ENG-1435


## Notes for Reviewer
- Waffle names should match what is found in https://github.com/CenterForOpenScience/ember-osf-preprints/pull/701

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`


[ENG-1435]: https://openscience.atlassian.net/browse/ENG-1435