### PR TITLE
[ENG-1435] Add coi section to submit page

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -212,6 +212,8 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     providerSaved: false,
     preprintSaved: false,
     submitAction: null,
+    // Auther assertion properties
+    // initialCoi: undefined,
 
     // Validation rules and changed states for form sections
 
@@ -523,6 +525,11 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
     canWithdraw: computed('moderationType', 'model.reviewsState', function() {
         const state = this.get('model.reviewsState');
         return (state === PENDING || state === ACCEPTED) && this.get('isAdmin');
+    }),
+    // Assertion panels
+    hasCoi: computed('model.hasCoi', function() {
+        const modelHasCoi = this.get('model.hasCoi');
+        return modelHasCoi;
     }),
 
     actions: {
@@ -949,6 +956,13 @@ export default Controller.extend(Analytics, BasicsValidations, NodeActionsMixin,
         },
         currentUserRemoved() {
             this.replaceRoute('index');
+        },
+
+        /*
+        Update Auther Assertion Sections
+        */
+        updateCoi(val) {
+            this.set('hasCoi', val);
         },
 
         /*

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -308,7 +308,16 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     savedCoi: computed.notEmpty('model.hasCoi'),
 
     // Preprint can be published once all required sections have been saved.
-    allSectionsValid: computed.and('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi'),
+    allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', function() {
+        if (this.get('shouldShowCoiPanel')) {
+            return this.get('savedTitle') && this.get('savedFile')
+            && this.get('savedAbstract') && this.get('savedSubjects')
+            && this.get('authorsValid') && this.get('savedCoi');
+        }
+        return this.get('savedTitle') && this.get('savedFile')
+            && this.get('savedAbstract') && this.get('savedSubjects')
+            && this.get('authorsValid');
+    }),
 
     // Are there any unsaved changes in the upload section?
     uploadChanged: computed.or('preprintFileChanged', 'titleChanged'),

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -200,6 +200,8 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     basicsSaveState: false,
     // True temporarily when changes have been saved in authors section
     authorsSaveState: false,
+    // True temporarily when changes have been saved in coi section
+    coiSaveState: false,
     // True temporarily when changes have been saved in the supplemental section
     supplementalSaveState: false,
     // Preprint node's osfStorage object
@@ -284,8 +286,11 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     // Does preprint have saved subjects?
     savedSubjects: computed.notEmpty('model.subjects'),
 
+    // Does preprint have saved coi?
+    savedCoi: computed.notEmpty('model.hasCoi'),
+
     // Preprint can be published once all required sections have been saved.
-    allSectionsValid: computed.and('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid'),
+    allSectionsValid: computed.and('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi'),
 
     // Are there any unsaved changes in the upload section?
     uploadChanged: computed.or('preprintFileChanged', 'titleChanged'),
@@ -563,7 +568,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     coiValid: computed('coiStatementValid', 'hasCoi', function() {
         const hasCoi = this.get('hasCoi');
         const coiStatementValid = this.get('coiStatementValid');
-
         if ((hasCoi && coiStatementValid) || hasCoi === false) {
             return true;
         }
@@ -1638,6 +1642,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
             disciplineSaveState: false,
             basicsSaveState: false,
             authorsSaveState: false,
+            coiSaveState: false,
             supplementalSaveState: false,
             osfStorageProvider: null,
             osfProviderLoaded: false,

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1033,6 +1033,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
                 model.set('hasCoi', this.get('hasCoi'));
                 model.set('conflictOfInterestStatement', this.get('coiStatement'));
             } else {
+                model.set('conflictOfInterestStatement', undefined);
                 model.set('hasCoi', this.get('hasCoi'));
             }
 

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -549,7 +549,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         return this.get('model.conflictOfInterestStatement') || null;
     }),
     hasCoi: computed('model.hasCoi', function() {
-        return this.get('model.hasCoi') || undefined;
+        return this.get('model.hasCoi');
     }),
     coiOptionChanged: computed('hasCoi', 'model.hasCoi', function() {
         const hasCoi = this.get('hasCoi');
@@ -1029,16 +1029,14 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
             const model = this.get('model');
 
-            if (this.get('hasCoi')) {
-                model.set('hasCoi', this.get('hasCoi'));
-                model.set('conflictOfInterestStatement', this.get('coiStatement'));
-            } else {
-                model.set('conflictOfInterestStatement', undefined);
-                model.set('hasCoi', this.get('hasCoi'));
+            if (!this.get('hasCoi')) {
+                this.set('coiStatement', undefined);
             }
 
-            this.set('model', model);
+            model.set('hasCoi', this.get('hasCoi'));
+            model.set('conflictOfInterestStatement', this.get('coiStatement'));
 
+            this.set('model', model);
             model.save()
                 .then(this._moveFromCoi.bind(this))
                 .catch(this._failMoveFromCoi.bind(this));

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -238,7 +238,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     licenseValid: false,
 
     _names: computed('shouldShowCoiPanel', 'shouldShowAuthorAssertionsPanel', function() {
-        if (this.get('shouldShowCoiPanel')) {
+        if (this.get('shouldShowCoiPanel') && !this.get('shouldShowAuthorAssertionsPanel')) {
             return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
         }
         if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -237,7 +237,15 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     // Must have year and copyrightHolders filled if those are required by the licenseType selected
     licenseValid: false,
 
-    _names: ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'], // Form section headers
+    _names: computed('shouldShowCoiPanel', 'shouldShowAuthorAssertionsPanel', function() {
+        if (this.get('shouldShowCoiPanel')) {
+            return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
+        }
+        if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {
+            return ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
+        }
+        return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'];
+    }),
     hasFile: computed.or('file', 'selectedFile'),
     isAddingPreprint: computed.not('editMode'),
     // Contributors on preprint
@@ -257,6 +265,16 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     sloanCoiInputEnabled: alias('features.sloanCoiInput'),
     sloanDataInputEnabled: alias('features.sloanDataInput'),
     sloanPreregInputEnabled: alias('features.sloanPreregInput'),
+
+    // Variable controlled by sloan waffle flags
+    shouldShowAuthorAssertionsPanel: computed('sloanDataInputEnabled', 'sloanPreregInputEnabled', 'currentProvider.inSloanStudy', function () {
+        if (!this.get('currentProvider.inSloanStudy')) {
+            return false;
+        }
+        return this.get('sloanPreregInputEnabled') || this.get('sloanDataInputEnabled');
+    }),
+
+    shouldShowCoiPanel: computed.and('sloanCoiInputEnabled', 'currentProvider.inSloanStudy'),
 
     // Basics fields that are being validated are abstract, license and doi
     // (title validated in upload section). If validation
@@ -704,7 +722,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
             });
             // Closes section, so all panels closed if Upload section revisited
             this.get('panelActions').close('uploadNewFile');
-            this.send('next', this.get('_names.2'));
+            this.send('next', this.get('_names.1'));
         },
 
         createPreprintCopyFile() {
@@ -1433,11 +1451,11 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     },
 
     _moveFromBasics() {
-        this.send('next', this.get('_names.3'));
+        this.send('next', 'Basics');
     },
 
     _moveFromCoi() {
-        this.send('next', this.get('_names.6'));
+        this.send('next', 'COI');
     },
 
     _failMoveFromCoi() {
@@ -1446,7 +1464,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     },
 
     _moveFromSupplemental() {
-        this.send('next', this.get('_names.7'));
+        this.send('next', 'Supplemental');
     },
 
     _failMoveFromBasics() {
@@ -1456,7 +1474,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     },
 
     _moveFromDisciplines() {
-        this.send('next', this.get('_names.4'));
+        this.send('next', 'Discipline');
     },
 
     _failMoveFromDisciplines() {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -237,15 +237,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     // Must have year and copyrightHolders filled if those are required by the licenseType selected
     licenseValid: false,
 
-    _names: computed('shouldShowCoiPanel', 'shouldShowAuthorAssertionsPanel', function() {
-        if (this.get('shouldShowCoiPanel') && !this.get('shouldShowAuthorAssertionsPanel')) {
-            return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
-        }
-        if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {
-            return ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
-        }
-        return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'];
-    }),
     hasFile: computed.or('file', 'selectedFile'),
     isAddingPreprint: computed.not('editMode'),
     // Contributors on preprint
@@ -265,14 +256,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     sloanCoiInputEnabled: alias('features.sloanCoiInput'),
     sloanDataInputEnabled: alias('features.sloanDataInput'),
     sloanPreregInputEnabled: alias('features.sloanPreregInput'),
-
-    // Variable controlled by sloan waffle flags
-    shouldShowAuthorAssertionsPanel: computed('sloanDataInputEnabled', 'sloanPreregInputEnabled', 'currentProvider.inSloanStudy', function () {
-        if (!this.get('currentProvider.inSloanStudy')) {
-            return false;
-        }
-        return this.get('sloanPreregInputEnabled') || this.get('sloanDataInputEnabled');
-    }),
 
     shouldShowCoiPanel: computed.and('sloanCoiInputEnabled', 'currentProvider.inSloanStudy'),
 
@@ -307,18 +290,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     // Does preprint have saved coi?
     savedCoi: computed.notEmpty('model.hasCoi'),
 
-    // Preprint can be published once all required sections have been saved.
-    allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', function() {
-        if (this.get('shouldShowCoiPanel')) {
-            return this.get('savedTitle') && this.get('savedFile')
-            && this.get('savedAbstract') && this.get('savedSubjects')
-            && this.get('authorsValid') && this.get('savedCoi');
-        }
-        return this.get('savedTitle') && this.get('savedFile')
-            && this.get('savedAbstract') && this.get('savedSubjects')
-            && this.get('authorsValid');
-    }),
-
     // Are there any unsaved changes in the upload section?
     uploadChanged: computed.or('preprintFileChanged', 'titleChanged'),
 
@@ -335,6 +306,36 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     coiChanged: computed.or('coiStatementChanged', 'coiOptionChanged'),
 
     moderationType: alias('currentProvider.reviewsWorkflow'),
+
+    _names: computed('shouldShowCoiPanel', 'shouldShowAuthorAssertionsPanel', function() {
+        if (this.get('shouldShowCoiPanel') && !this.get('shouldShowAuthorAssertionsPanel')) {
+            return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
+        }
+        if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {
+            return ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
+        }
+        return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'];
+    }),
+
+    // Variable controlled by sloan waffle flags
+    shouldShowAuthorAssertionsPanel: computed('sloanDataInputEnabled', 'sloanPreregInputEnabled', 'currentProvider.inSloanStudy', function () {
+        if (!this.get('currentProvider.inSloanStudy')) {
+            return false;
+        }
+        return this.get('sloanPreregInputEnabled') || this.get('sloanDataInputEnabled');
+    }),
+
+    // Preprint can be published once all required sections have been saved.
+    allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', function() {
+        if (this.get('shouldShowCoiPanel')) {
+            return this.get('savedTitle') && this.get('savedFile')
+            && this.get('savedAbstract') && this.get('savedSubjects')
+            && this.get('authorsValid') && this.get('savedCoi');
+        }
+        return this.get('savedTitle') && this.get('savedFile')
+            && this.get('savedAbstract') && this.get('savedSubjects')
+            && this.get('authorsValid');
+    }),
 
     supplementalChanged: computed('supplementalProjectTitle', 'pendingSupplementalProjectTitle', 'selectedSupplementalProject', 'node', function() {
         const savedTitle = this.get('supplementalProjectTitle');

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -325,7 +325,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     // Preprint can be published once all required sections have been saved.
     allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', function() {
-        const allSectionsValid = this.get('savedTitle') && this.get('savedFile') &&  this.get('savedAbstract') && this.get('savedSubjects') && this.get('authorsValid');
+        const allSectionsValid = this.get('savedTitle') && this.get('savedFile') && this.get('savedAbstract') && this.get('savedSubjects') && this.get('authorsValid');
         if (this.get('shouldShowCoiPanel')) {
             return allSectionsValid && this.get('savedCoi');
         }

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -325,14 +325,11 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     // Preprint can be published once all required sections have been saved.
     allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', function() {
+        const allSectionsValid = this.get('savedTitle') && this.get('savedFile') &&  this.get('savedAbstract') && this.get('savedSubjects') && this.get('authorsValid');
         if (this.get('shouldShowCoiPanel')) {
-            return this.get('savedTitle') && this.get('savedFile')
-            && this.get('savedAbstract') && this.get('savedSubjects')
-            && this.get('authorsValid') && this.get('savedCoi');
+            return allSectionsValid && this.get('savedCoi');
         }
-        return this.get('savedTitle') && this.get('savedFile')
-            && this.get('savedAbstract') && this.get('savedSubjects')
-            && this.get('authorsValid');
+        return allSectionsValid;
     }),
 
     supplementalChanged: computed('supplementalProjectTitle', 'pendingSupplementalProjectTitle', 'selectedSupplementalProject', 'node', function() {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -227,8 +227,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     providerSaved: false,
     preprintSaved: false,
     submitAction: null,
-    // Auther assertion properties
-    // initialCoi: undefined,
 
     // Validation rules and changed states for form sections
 
@@ -1030,7 +1028,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         },
 
         /*
-        Update Auther Assertion Sections
+        Update Author Assertion Sections
         */
         updateCoi(val) {
             this.set('hasCoi', val);

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -224,8 +224,10 @@ export default {
                 title: 'Conflict of Interest',
                 yes: 'Yes',
                 no: 'No',
+                describe: 'Describe: ',
                 placeholder: 'Author asserted no Conflict of Interest',
-                description: 'The Conflict of Interest (COI) assertion is made on behalf of all the authors listed for this {{documentType.singular}}. COI’s include: financial involvement in any entity such as honoraria, grants, speaking fees, employment, consultancies, stock ownership, expert testimony, and patents or licenses. COI’s can also include non-financial interests such as personal or professional relationships or pre-existing beliefs in the subject matter or materials discussed in this {{documentType.singular}}.',
+                coi_statement: 'Conflict of Interest statement',
+                description: 'The Conflict of Interest (COI) assertion is made on behalf of all the authors listed for this {{documentType.singular}}. COIs include: financial involvement in any entity such as honoraria, grants, speaking fees, employment, consultancies, stock ownership, expert testimony, and patents or licenses. COIs can also include non-financial interests such as personal or professional relationships or pre-existing beliefs in the subject matter or materials discussed in this {{documentType.singular}}.',
             },
             submit: {
                 information: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -220,6 +220,12 @@ export default {
             authors: {
                 paragraph: 'Add {{documentType.singular}} authors and order them appropriately. Search for authors that have OSF accounts or invite unregistered users to join by entering their email addresses.',
             },
+            conflict_of_interest: {
+                yes: 'Yes',
+                no: 'No',
+                placeholder: 'Author asserted no Conflict of Interest',
+                description: 'The Conflict of Interest (COI) assertion is made on behalf of all the authors listed for this {{documentType.singular}}. COI’s include: financial involvement in any entity such as honoraria, grants, speaking fees, employment, consultancies, stock ownership, expert testimony, and patents or licenses. COI’s can also include non-financial interests such as personal or professional relationships or pre-existing beliefs in the subject matter or materials discussed in this {{documentType.singular}}.',
+            },
             submit: {
                 information: {
                     line1: {
@@ -420,6 +426,7 @@ export default {
                 Discipline: 'Discipline',
                 Basics: 'Basics',
                 Authors: 'Authors',
+                COI: 'Conflict of Interest',
                 Submit: 'Submit',
                 Update: 'Update',
                 Supplemental: 'Supplemental materials',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -291,6 +291,7 @@ export default {
         doi_error: 'Error saving DOI',
         basics_error: 'Error saving basics fields.',
         disciplines_error: 'Error saving discipline(s).',
+        coi_error: 'Error saving COI field(s).',
         search_contributors_error: 'Could not perform search query.',
         server_locked: 'You cannot change the paper service after a file has been uploaded',
         please_select_server: 'Please select a paper service before continuing',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -221,6 +221,7 @@ export default {
                 paragraph: 'Add {{documentType.singular}} authors and order them appropriately. Search for authors that have OSF accounts or invite unregistered users to join by entering their email addresses.',
             },
             conflict_of_interest: {
+                title: 'Conflict of Interest',
                 yes: 'Yes',
                 no: 'No',
                 placeholder: 'Author asserted no Conflict of Interest',

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -924,7 +924,7 @@ hr {
         content: "(required)";
         color: lighten(red, 30%);
         font-weight: normal;
-        float: right;
+        margin-left: 5px;
     }
 
     label.coiRadioLabel {
@@ -941,6 +941,11 @@ hr {
         color: #263947;
         padding: 20px;
         margin-bottom: 15px;
+    }
+
+    textarea {
+        resize: vertical;
+        min-height: 52px;
     }
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -919,15 +919,32 @@ hr {
     }
 }
 
-#supplemental-materials {
+#author-coi-assertion {
     span.required:after {
         content: "(required)";
         color: lighten(red, 30%);
         font-weight: normal;
         float: right;
     }
+
+    label.coiRadioLabel {
+        display: inline;
+        font-weight: normal;
+    }
+
+    label.coiRadioLabel:first-of-type {
+        margin-right: 15px;
+    }
+
+    .assertionDescription {
+        background-color: #eee;
+        color: #263947;
+        padding: 20px;
+        margin-bottom: 15px;
+    }
 }
 
+#supplemental-materials,
 #preprint-form-basics {
     span.required:after {
         content: "(required)";

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -12,7 +12,8 @@
         (and basicsSaveState (eq name 'Basics'))
         (and authorsSaveState (eq name 'Authors'))
         (and supplementalSaveState (eq name 'Supplemental'))
-        (and disciplineSaveState (eq name 'Discipline')) )}}
+        (and disciplineSaveState (eq name 'Discipline'))
+        (and coiSaveState (eq name 'COI')) )}}
         <span class="text-success text-smaller m-r-md"> {{t "components.preprint-form-header.changes_saved"}} </span>
     {{/if}}
     {{#if showValidationIndicator}}
@@ -93,6 +94,19 @@
                         </li>
                     {{~/each}}
                 </ul>
+            {{else if (eq name 'COI')}}
+                <p>
+                    <em class="m-r-md">
+                        {{t "submit.body.conflict_of_interest.title"}}: 
+                    </em>
+                    {{if hasCoi (t "submit.body.conflict_of_interest.yes") (t "submit.body.conflict_of_interest.no")}}
+                </p>
+                <p>
+                    <em class="m-r-md">
+                        {{t "submit.body.conflict_of_interest.coi_statement"}}: 
+                    </em>
+                    {{if (and hasCoi coiStatement) coiStatement (t "submit.body.conflict_of_interest.placeholder")}}
+                </p>
             {{/if}}
         {{/if}}
 

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -96,15 +96,7 @@
                 </ul>
             {{else if (eq name 'COI')}}
                 <p>
-                    <em class="m-r-md">
-                        {{t "submit.body.conflict_of_interest.title"}}: 
-                    </em>
-                    {{if hasCoi (t "submit.body.conflict_of_interest.yes") (t "submit.body.conflict_of_interest.no")}}
-                </p>
-                <p>
-                    <em class="m-r-md">
-                        {{t "submit.body.conflict_of_interest.coi_statement"}}: 
-                    </em>
+                    {{if hasCoi (t "submit.body.conflict_of_interest.yes") (t "submit.body.conflict_of_interest.no")}}: 
                     {{if (and hasCoi coiStatement) coiStatement (t "submit.body.conflict_of_interest.placeholder")}}
                 </p>
             {{/if}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -434,6 +434,7 @@
                                         <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                         <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
                                         <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
+                                        <p class="text-danger">{{unless coiValid (t "global.body.submit.conflict_of_interest.title")}}</p>
                                     </span>
                                 {{/if}}
                                 <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -251,8 +251,8 @@
 
                     {{! ==== COI HERE ==== }}
                     {{#with _names.[6] as |name|}}
-                        {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=true canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode node=node name=name valid=coiStatementValid isValidationActive=hasOpened}}
+                        {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header editMode=editMode node=node name=name valid=coiValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div role='radiogroup'>
                                     <input
@@ -263,16 +263,16 @@
                                         onchange={{action "updateCoi" true}}
                                         checked={{hasCoi}}
                                     >
-                                    <label class='coiRadioLabel' for="coiYes">{{t "submit.body.general.yes"}}</label>
+                                    <label class='coiRadioLabel' for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
                                     <input
                                         type="radio"
                                         id="coiNo"
                                         name="coi"
                                         value="No"
                                         onchange={{action "updateCoi" false}}
-                                        checked={{if (and (not hasCoi) not-eq hasCoi undefined) true}}
+                                        checked={{if (and (not hasCoi) (not-eq hasCoi undefined)) true}}
                                     >
-                                    <label class='coiRadioLabel' for="coiNo">{{t "submit.body.general.no"}}</label>
+                                    <label class='coiRadioLabel' for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
                                 </div>
                                 <br>
                                 {{#if hasCoi}}
@@ -289,8 +289,8 @@
                                 <div class="row">
                                     <div class="col-md-12">
                                         <div class="pull-right">
-                                            <button {{action 'discardCoi'}} class="btn btn-default" disabled={{unless coiStatementChanged true}} >{{t "global.discard"}}</button>
-                                            <button {{action 'saveCoi'}} class="btn btn-primary" disabled={{unless coiStatementValid true}} >{{t "submit.body.save_continue"}}</button>
+                                            <button {{action 'discardCoi'}} class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
+                                            <button {{action 'saveCoi'}} class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
                                         </div>
                                     </div>
                                 </div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -15,7 +15,7 @@
             <div class="col-xs-12 col-md-10 col-md-offset-1 ">
                 {{#cp-panels accordion=true}}
                     {{#if (not (or editMode theme.isProvider))}}
-                        {{#with _names.[0] as |name|}}
+                        {{#with "Server" as |name|}}
                             {{#preprint-form-section id='preprint-form-server' editMode=editMode canEdit=canEdit open=true name=name allowOpen=(not uploadValid) denyOpenMessage=(t 'submit.server_locked') errorAction=(action 'error')}}
                                 {{preprint-form-header editMode=editMode serverSaveState=serverSaveState showValidationIndicator=true name=name isValidationActive=(and providerSaved (not uploadValid)) currentProvider=currentProvider valid=(not providerChanged)}}
                                 {{#preprint-form-body}}
@@ -51,7 +51,7 @@
                         {{/with}}
                     {{/if}}
 
-                    {{#with _names.[1] as |name|}}
+                    {{#with "File" as |name|}}
                         {{#preprint-form-section
                             editMode=editMode
                             class=(concat 'preprint-form-upload' (if uploadInProgress ' upload-in-progress'))
@@ -136,21 +136,23 @@
                     {{/with}}
 
                     {{! ===== AUTHOR ASSERTIONS HERE ===== }}
-                    {{!-- Add logic for Data availability here --}}
-                    {{!-- No: Optional textarea
-                        NA: Disabled Textbox with placeholder
-                        Available: required multiple textbox for links
-                    --}}
-                    {{!-- Section explaining Data Avaliability here --}}
+                    {{#if shouldShowAuthorAssertionsPanel}}
+                        {{!-- Add logic for Data availability here --}}
+                        {{!-- No: Optional textarea
+                            NA: Disabled Textbox with placeholder
+                            Available: required multiple textbox for links
+                        --}}
+                        {{!-- Section explaining Data Avaliability here --}}
 
-                    {{!-- Add logic for Prereg here --}}
-                    {{!-- No: Optional textarea
-                        NA: Disabled Textbox with placeholder
-                        Available: required multiple textbox for links, dropdown to denote type
-                    --}}
-                    {{!-- Section explaining Prereg here --}}
+                        {{!-- Add logic for Prereg here --}}
+                        {{!-- No: Optional textarea
+                            NA: Disabled Textbox with placeholder
+                            Available: required multiple textbox for links, dropdown to denote type
+                        --}}
+                        {{!-- Section explaining Prereg here --}}
+                    {{/if}}
 
-                    {{#with _names.[3] as |name|}}
+                    {{#with "Basics" as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=model.tags abstract=model.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -201,7 +203,7 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#with _names.[4] as |name|}}
+                    {{#with "Discipline" as |name|}}
                         {{#preprint-form-section id='preprint-form-subjects' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode disciplineSaveState=disciplineSaveState subjects=disciplineReduced name=name valid=(not disciplineChanged) isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -219,7 +221,7 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#with _names.[5] as |name|}}
+                    {{#with "Authors" as |name|}}
                         {{#preprint-form-section id='preprint-form-authors' editMode=editMode name=name allowOpen=uploadValid open=authorsOpen errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode authorsSaveState=authorsSaveState authors=contributors name=name valid=authorsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
@@ -250,56 +252,58 @@
                     {{/with}}
 
                     {{! ==== COI HERE ==== }}
-                    {{#with _names.[6] as |name|}}
-                        {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
-                            {{#preprint-form-body}}
-                                <div role='radiogroup'>
-                                    <input
-                                        type="radio"
-                                        id="coiYes"
-                                        name="coi"
-                                        value="Yes"
-                                        onchange={{action "updateCoi" true}}
-                                        checked={{hasCoi}}
-                                    >
-                                    <label class='coiRadioLabel' for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="coiNo"
-                                        name="coi"
-                                        value="No"
-                                        onchange={{action "updateCoi" false}}
-                                        checked={{if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null))) true}}
-                                    >
-                                    <label class='coiRadioLabel' for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
-                                    <span class='required' />
-                                </div>
-                                <br>
-                                {{#if hasCoi}}
-                                    <label for='coiStatement'>{{t "submit.body.conflict_of_interest.describe"}} <span class='required' /></label>
-                                    {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
-                                {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
-                                    <div class='form-group'>
-                                        <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                    {{#if shouldShowCoiPanel}}
+                        {{#with "COI" as |name|}}
+                            {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                                {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
+                                {{#preprint-form-body}}
+                                    <div role='radiogroup'>
+                                        <input
+                                            type="radio"
+                                            id="coiYes"
+                                            name="coi"
+                                            value="Yes"
+                                            onchange={{action "updateCoi" true}}
+                                            checked={{hasCoi}}
+                                        >
+                                        <label class='coiRadioLabel' for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="coiNo"
+                                            name="coi"
+                                            value="No"
+                                            onchange={{action "updateCoi" false}}
+                                            checked={{if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null))) true}}
+                                        >
+                                        <label class='coiRadioLabel' for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
+                                        <span class='required' />
                                     </div>
-                                {{/if}}
-                                <div class="assertionDescription">
-                                    {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
-                                </div>
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <div class="pull-right">
-                                            <button {{action 'discardCoi'}} class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
-                                            <button {{action 'saveCoi'}} class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
+                                    <br>
+                                    {{#if hasCoi}}
+                                        <label for='coiStatement'>{{t "submit.body.conflict_of_interest.describe"}} <span class='required' /></label>
+                                        {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
+                                    {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
+                                        <div class='form-group'>
+                                            <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                                        </div>
+                                    {{/if}}
+                                    <div class="assertionDescription">
+                                        {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="pull-right">
+                                                <button {{action 'discardCoi'}} class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
+                                                <button {{action 'saveCoi'}} class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            {{/preprint-form-body}}
-                        {{/preprint-form-section}}
-                    {{/with}}
+                                {{/preprint-form-body}}
+                            {{/preprint-form-section}}
+                        {{/with}}
+                    {{/if}}
 
-                    {{#with _names.[7] as |name|}}
+                    {{#with "Supplemental" as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode supplementalSaveState=supplementalSaveState supplementalProjectTitle=supplementalProjectTitle node=node name=name valid=(not supplementalChanged) isValidationActive=hasOpened}}
                             {{#preprint-form-body}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -252,7 +252,7 @@
                     {{! ==== COI HERE ==== }}
                     {{#with _names.[6] as |name|}}
                         {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode node=node name=name valid=coiValid isValidationActive=hasOpened}}
+                            {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div role='radiogroup'>
                                     <input
@@ -270,15 +270,16 @@
                                         name="coi"
                                         value="No"
                                         onchange={{action "updateCoi" false}}
-                                        checked={{if (and (not hasCoi) (not-eq hasCoi undefined)) true}}
+                                        checked={{if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null))) true}}
                                     >
                                     <label class='coiRadioLabel' for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
+                                    <span class='required' />
                                 </div>
                                 <br>
                                 {{#if hasCoi}}
-                                    <label for='coiStatement'>Describe: <span class='required' /></label>
+                                    <label for='coiStatement'>{{t "submit.body.conflict_of_interest.describe"}} <span class='required' /></label>
                                     {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
-                                {{else if (and (not hasCoi) (not-eq hasCoi undefined))}}
+                                {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
                                     <div class='form-group'>
                                         <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
                                     </div>
@@ -434,7 +435,7 @@
                                         <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                         <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
                                         <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
-                                        <p class="text-danger">{{unless coiValid (t "global.body.submit.conflict_of_interest.title")}}</p>
+                                        <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
                                     </span>
                                 {{/if}}
                                 <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -252,7 +252,7 @@
                     {{! ==== COI HERE ==== }}
                     {{#with _names.[6] as |name|}}
                         {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=true canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode node=node name=name valid=true isValidationActive=hasOpened}}
+                            {{preprint-form-header editMode=editMode node=node name=name valid=coiStatementValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div role='radiogroup'>
                                     <input
@@ -263,7 +263,7 @@
                                         onchange={{action "updateCoi" true}}
                                         checked={{hasCoi}}
                                     >
-                                    <label class='coiRadioLabel' for="coiyes">{{t "submit.body.general.yes"}}</label>
+                                    <label class='coiRadioLabel' for="coiYes">{{t "submit.body.general.yes"}}</label>
                                     <input
                                         type="radio"
                                         id="coiNo"
@@ -277,7 +277,7 @@
                                 <br>
                                 {{#if hasCoi}}
                                     <label for='coiStatement'>Describe: <span class='required' /></label>
-                                    {{validated-input id='coiStatement' inputType='textarea' model=model valuePath='conflictOfInterestStatement' documentType=currentProvider.documentType value=model.conflictOfInterestStatement}}
+                                    {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
                                 {{else if (and (not hasCoi) (not-eq hasCoi undefined))}}
                                     <div class='form-group'>
                                         <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
@@ -289,8 +289,8 @@
                                 <div class="row">
                                     <div class="col-md-12">
                                         <div class="pull-right">
-                                            <button {{action 'discardBasics'}} class="btn btn-default" disabled={{unless basicsChanged true}} >{{t "global.discard"}}</button>
-                                            <button {{action 'saveBasics'}} class="btn btn-primary" disabled={{unless basicsValid true}} >{{t "submit.body.save_continue"}}</button>
+                                            <button {{action 'discardCoi'}} class="btn btn-default" disabled={{unless coiStatementChanged true}} >{{t "global.discard"}}</button>
+                                            <button {{action 'saveCoi'}} class="btn btn-primary" disabled={{unless coiStatementValid true}} >{{t "submit.body.save_continue"}}</button>
                                         </div>
                                     </div>
                                 </div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -439,7 +439,9 @@
                                         <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                         <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
                                         <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
-                                        <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
+                                        {{#if shouldShowCoiPanel}}
+                                            <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
+                                        {{/if}}
                                     </span>
                                 {{/if}}
                                 <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -250,11 +250,53 @@
                     {{/with}}
 
                     {{! ==== COI HERE ==== }}
-                    {{!-- Add logic for COI here --}}
-                    {{!-- No: Disabled Textbox with placeholder
-                        Yes: Required textarea to describe
-                    --}}
-                    {{!-- Section explaining COI here --}}
+                    {{#with _names.[6] as |name|}}
+                        {{#preprint-form-section id="author-coi-assertion" editMode=editMode name=name allowOpen=true canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header editMode=editMode node=node name=name valid=true isValidationActive=hasOpened}}
+                            {{#preprint-form-body}}
+                                <div role='radiogroup'>
+                                    <input
+                                        type="radio"
+                                        id="coiYes"
+                                        name="coi"
+                                        value="Yes"
+                                        onchange={{action "updateCoi" true}}
+                                        checked={{hasCoi}}
+                                    >
+                                    <label class='coiRadioLabel' for="coiyes">{{t "submit.body.general.yes"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="coiNo"
+                                        name="coi"
+                                        value="No"
+                                        onchange={{action "updateCoi" false}}
+                                        checked={{if (and (not hasCoi) not-eq hasCoi undefined) true}}
+                                    >
+                                    <label class='coiRadioLabel' for="coiNo">{{t "submit.body.general.no"}}</label>
+                                </div>
+                                <br>
+                                {{#if hasCoi}}
+                                    <label for='coiStatement'>Describe: <span class='required' /></label>
+                                    {{validated-input id='coiStatement' inputType='textarea' model=model valuePath='conflictOfInterestStatement' documentType=currentProvider.documentType value=model.conflictOfInterestStatement}}
+                                {{else if (and (not hasCoi) (not-eq hasCoi undefined))}}
+                                    <div class='form-group'>
+                                        <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                                    </div>
+                                {{/if}}
+                                <div class="assertionDescription">
+                                    {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="pull-right">
+                                            <button {{action 'discardBasics'}} class="btn btn-default" disabled={{unless basicsChanged true}} >{{t "global.discard"}}</button>
+                                            <button {{action 'saveBasics'}} class="btn btn-primary" disabled={{unless basicsValid true}} >{{t "submit.body.save_continue"}}</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            {{/preprint-form-body}}
+                        {{/preprint-form-section}}
+                    {{/with}}
 
                     {{#with _names.[7] as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -264,7 +264,6 @@
                                             name="coi"
                                             value="Yes"
                                             onchange={{action "updateCoi" true}}
-                                            checked={{hasCoi}}
                                         >
                                         <label class='coiRadioLabel' for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
                                         <input
@@ -284,7 +283,7 @@
                                         {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
                                     {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
                                         <div class='form-group'>
-                                            <input type="text" class='form-control' disabled={{true}} placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                                            <input type="text" class='form-control' disabled placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
                                         </div>
                                     {{/if}}
                                     <div class="assertionDescription">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hotfix": "git flow hotfix start rename-me && npm --no-git-tag-version version patch && git ci package.json -m 'Bump version' && git br -m \"hotfix/$(npm version | head -1 | grep -o '[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+')\""
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#0.27.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#f815723f23a78e78e0c5cffcc12362dd0d2682ce",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "autoprefixer": "^7.1.2",

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -99,7 +99,7 @@ test('Initial properties', function (assert) {
         '_State.EXISTING': 'existing',
         filePickerState: 'start',
         supplementalPickerState: 'start',
-        '_names.length': 8,
+        '_names.length': 6,
         user: null,
         'availableLicenses.length': 0,
         node: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,9 +968,9 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#0.27.0":
-  version "0.27.0"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2e6125f87dcba2860914e30fc1f10b91ea428504"
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#f815723f23a78e78e0c5cffcc12362dd0d2682ce":
+  version "0.29.0"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#f815723f23a78e78e0c5cffcc12362dd0d2682ce"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Purpose
To add the COI section to the submit/edit page


## Summary of Changes/Side Effects

- [x] Add COI section in placeholder
- [x] Add toggle for text/textarea display
- [x] Add styling
- [x] Add translations (will be added with other PR)
- [x] Update final validation to check if section is valid
- [x] Add computed to check if changes happened and if the user can `discard changes/save & continue` for buttons
- [x] Ensure that fields are properly connected to model

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->


## Ticket

https://openscience.atlassian.net/browse/ENG-1435

## Notes for Reviewer

This will only be adding the COI section to the submit/edit page. The field itself will be unchecked on the first run through of the form. The form cannot be submitted until the user either checks `No` or `Yes` and fills out the description box. The submit button at the end of the form will be disabled until that section is also valid, and will show `Conflict Of Interest` in the list of necessary fields still required for submit. The `describe` box will have a validation of 10 words minimum and a 5000 word limit. A validation message should appear at the bottom of the textarea if the user tries to move on without meeting those validations.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
