### PR TITLE
[ENG-1435]Add component to handle multiple text inputs

### DIFF
--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -1,0 +1,37 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { task, timeout } from 'ember-concurrency';
+import Analytics from 'ember-osf/mixins/analytics';
+
+export default Component.extend(Analytics, {
+    textFields: null, // passed in array of text fields on invocation, default to null
+    alphabet: 'abcdefghijklmnop',
+    textFieldsLastIndex: computed('textFields.[]', function() {
+        return this.get('textFields').length - 1;
+    }),
+
+    actions: {
+        addTextField() {
+            let fields = this.get('textFields');
+            if (!fields) {
+                fields = [$('.ember-text-field')[0].value];
+            }
+            fields.pushObject('');
+            this.set('textFields', fields);
+        },
+        removeTextField(index) {
+            const fields = this.get('textFields');
+            fields.removeAt(index);
+            this.set('textFields', fields);
+        },
+    },
+    onFieldChange: task(function* (index) {
+        yield timeout(200); // debounce
+        let fields = this.get('textFields');
+        if (!fields) {
+            fields = [$('.ember-text-field')[0].value];
+        }
+        fields[index] = $('.ember-text-field')[index].value;
+        this.set('textFields', fields);
+    }).restartable(),
+});

--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import Analytics from 'ember-osf/mixins/analytics';
 
 export default Component.extend(Analytics, {
+    legend: 'Text Fields',
     textFields: null, // passed in array of text fields on invocation, default to null
     textFieldsLastIndex: computed('textFields.[]', function() {
         return this.get('textFields').length - 1;

--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { task, timeout } from 'ember-concurrency';
 import Analytics from 'ember-osf/mixins/analytics';
 
 export default Component.extend(Analytics, {
@@ -10,13 +9,19 @@ export default Component.extend(Analytics, {
         return this.get('textFields').length - 1;
     }),
 
+    didReceiveAttrs() {
+        if (!this.textFields) {
+            this.set('textFields', [{ value: '' }]);
+        }
+    },
+
     actions: {
         addTextField() {
             let fields = this.get('textFields');
             if (!fields) {
-                fields = [$('.ember-text-field')[0].value];
+                fields = [{ value: '' }];
             }
-            fields.pushObject('');
+            fields.pushObject({ value: '' });
             this.set('textFields', fields);
         },
         removeTextField(index) {
@@ -25,13 +30,4 @@ export default Component.extend(Analytics, {
             this.set('textFields', fields);
         },
     },
-    onFieldChange: task(function* (index) {
-        yield timeout(200); // debounce
-        let fields = this.get('textFields');
-        if (!fields) {
-            fields = [$('.ember-text-field')[0].value];
-        }
-        fields[index] = $('.ember-text-field')[index].value;
-        this.set('textFields', fields);
-    }).restartable(),
 });

--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -5,7 +5,6 @@ import Analytics from 'ember-osf/mixins/analytics';
 
 export default Component.extend(Analytics, {
     textFields: null, // passed in array of text fields on invocation, default to null
-    alphabet: 'abcdefghijklmnop',
     textFieldsLastIndex: computed('textFields.[]', function() {
         return this.get('textFields').length - 1;
     }),

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1673,6 +1673,13 @@ button.provider.inactive-provider {
     margin-top: 20px;
 }
 
+.multi-textbox.row {
+    margin-top: 10px;
+    .text-line {
+        margin-bottom: 10px;
+    }
+}
+
 img.current-provider {
     vertical-align: middle;
     height: 30px;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1673,13 +1673,6 @@ button.provider.inactive-provider {
     margin-top: 20px;
 }
 
-.multi-textbox.row {
-    margin-top: 10px;
-    .text-line {
-        margin-bottom: 10px;
-    }
-}
-
 img.current-provider {
     vertical-align: middle;
     height: 30px;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -766,6 +766,16 @@ $color-border-light: #DDDDDD;
 
 // FOR FORMS ON THE PREPRINTS AND ADD-PREPRINTS PAGE
 
+.text-input-row{
+    width: 100%;
+    padding: 10px;
+    display: inline-flex;
+
+    .btn {
+        margin-left: 5px;
+    }
+}
+
 .show-more-button {
     background: 0;
     border: 0;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -766,7 +766,12 @@ $color-border-light: #DDDDDD;
 
 // FOR FORMS ON THE PREPRINTS AND ADD-PREPRINTS PAGE
 
-.text-input-row{
+.text-fields-legend {
+    font-size: 16px;
+    border-bottom: none;
+}
+
+.text-input-row {
     width: 100%;
     padding: 10px;
     display: inline-flex;

--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -1,0 +1,21 @@
+<div class="multi-textbox row">
+    {{#each textFields key="id" as |field index|}}
+        <div class="col-xs-9 text-line">
+            {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }} {{! key-up=(perform onFieldChange index) }}
+        </div>
+        <div class="col-xs-3 text-line">
+            {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
+                <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}}>Remove</button>
+            {{else}}
+                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>Add</button>
+            {{/if}}
+        </div>
+    {{else}}
+        <div class="col-xs-9">
+            {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }} {{! key-up=(perform onFieldChange 0) }}
+        </div>
+        <div class="col-xs-3">
+            <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>Add</button>
+        </div> 
+    {{/each}}
+</div>

--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -1,21 +1,21 @@
-<div class="multi-textbox row">
+<div class="row">
     {{#each textFields key="id" as |field index|}}
-        <div class="col-xs-9 text-line">
+        <div class="col-xs-11 p-t-xs">
             {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }} {{! key-up=(perform onFieldChange index) }}
         </div>
-        <div class="col-xs-3 text-line">
+        <div class="col-xs-1 p-t-xs">
             {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
-                <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}}>Remove</button>
+                <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}}>{{fa-icon 'minus'}}</button>
             {{else}}
-                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>Add</button>
+                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>{{fa-icon 'plus'}}</button>
             {{/if}}
         </div>
     {{else}}
-        <div class="col-xs-9">
+        <div class="col-xs-11">
             {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }} {{! key-up=(perform onFieldChange 0) }}
         </div>
-        <div class="col-xs-3">
-            <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>Add</button>
+        <div class="col-xs-1">
+            <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>{{fa-icon 'plus'}}</button>
         </div> 
     {{/each}}
 </div>

--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -1,17 +1,20 @@
-<div class="row">
-    {{#each textFields key="id" as |field index|}}
-        <div class="col-xs-12 p-t-xs text-input-row">
-            {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }}
-            {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
-                <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}}>{{fa-icon 'minus'}}</button>
-            {{else}}
-                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>{{fa-icon 'plus'}}</button>
-            {{/if}}
-        </div>
-    {{else}}
-        <div class="col-xs-12 p-t-xs text-input-row">
-            {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }}
-            <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>{{fa-icon 'plus'}}</button>
-        </div>
-    {{/each}}
-</div>
+<fieldset>
+    <legend class="text-fields-legend">{{legend}}</legend>
+    <div class="row">
+        {{#each textFields key="id" as |field index|}}
+            <div class="col-xs-12 p-t-xs text-input-row">
+                {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }}
+                {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
+                    <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}} aria-label='Remove text field'>{{fa-icon 'minus'}}</button>
+                {{else}}
+                    <button class="btn btn-success btn-small" onClick={{action 'addTextField'}} aria-label='Add another text field'>{{fa-icon 'plus'}}</button>
+                {{/if}}
+            </div>
+        {{else}}
+            <div class="col-xs-12 p-t-xs text-input-row">
+                {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }}
+                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}} aria-label='Add another text field'>{{fa-icon 'plus'}}</button>
+            </div>
+        {{/each}}
+    </div>
+</fieldset>

--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -3,17 +3,12 @@
     <div class="row">
         {{#each textFields key="id" as |field index|}}
             <div class="col-xs-12 p-t-xs text-input-row">
-                {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }}
+                {{input class="form-control ember-text-field" type="text" placeholder=placeholder value=field.value }}
                 {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
                     <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}} aria-label='Remove text field'>{{fa-icon 'minus'}}</button>
                 {{else}}
                     <button class="btn btn-success btn-small" onClick={{action 'addTextField'}} aria-label='Add another text field'>{{fa-icon 'plus'}}</button>
                 {{/if}}
-            </div>
-        {{else}}
-            <div class="col-xs-12 p-t-xs text-input-row">
-                {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }}
-                <button class="btn btn-success btn-small" onClick={{action 'addTextField'}} aria-label='Add another text field'>{{fa-icon 'plus'}}</button>
             </div>
         {{/each}}
     </div>

--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -1,9 +1,7 @@
 <div class="row">
     {{#each textFields key="id" as |field index|}}
-        <div class="col-xs-11 p-t-xs">
-            {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }} {{! key-up=(perform onFieldChange index) }}
-        </div>
-        <div class="col-xs-1 p-t-xs">
+        <div class="col-xs-12 p-t-xs text-input-row">
+            {{input class="form-control ember-text-field" type="text" placeholder=placeholder key-up=(perform onFieldChange index) value=field }}
             {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
                 <button class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}}>{{fa-icon 'minus'}}</button>
             {{else}}
@@ -11,11 +9,9 @@
             {{/if}}
         </div>
     {{else}}
-        <div class="col-xs-11">
-            {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }} {{! key-up=(perform onFieldChange 0) }}
-        </div>
-        <div class="col-xs-1">
+        <div class="col-xs-12 p-t-xs text-input-row">
+            {{input class="form-control ember-text-field" type="text" key-up=(perform onFieldChange index) placeholder=placeholder }}
             <button class="btn btn-success btn-small" onClick={{action 'addTextField'}}>{{fa-icon 'plus'}}</button>
-        </div> 
+        </div>
     {{/each}}
 </div>

--- a/tests/integration/components/multiple-textbox-input-test.js
+++ b/tests/integration/components/multiple-textbox-input-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 moduleForComponent('multiple-textbox-input', 'Integration | Component | multiple textbox input', {
     integration: true,
     beforeEach() {
-        this.set('textFields', ['ichi', 'ni', 'san', 'yon']);
+        this.set('textFields', [{ value: 'ichi' }, { value: 'ni' }, { value: 'san' }, { value: 'yon' }]);
     },
 });
 

--- a/tests/integration/components/multiple-textbox-input-test.js
+++ b/tests/integration/components/multiple-textbox-input-test.js
@@ -27,13 +27,13 @@ test('Can add and remove fields', function(assert) {
     this.$('.btn-danger')[0].click();
     assert.equal($('.ember-text-field').length, 3, 'has three text fields after single remove');
     assert.equal($('.btn-danger').length, 2, 'has two remove buttons after single remove');
-    assert.equal($('.ember-text-field')[0].value, "ni", 'old index 1 now index 0 after single remove');
-    assert.equal($('.ember-text-field')[2].value, "yon", 'old index 3 now index 2 after single remove');
+    assert.equal($('.ember-text-field')[0].value, 'ni', 'old index 1 now index 0 after single remove');
+    assert.equal($('.ember-text-field')[2].value, 'yon', 'old index 3 now index 2 after single remove');
     this.$('.btn-success')[0].click();
     assert.equal($('.ember-text-field').length, 4, 'has 4 text fields after single add');
     assert.equal($('.btn-danger').length, 3, 'has three remove buttons after single remove');
-    assert.equal($('.ember-text-field')[0].value, "ni", 'existing index 0 unchanged by add');
-    assert.equal($('.ember-text-field')[2].value, "yon", 'existing index 2 unchanged by add');
-    assert.equal($('.ember-text-field')[3].value, "", 'new text field is empty');
+    assert.equal($('.ember-text-field')[0].value, 'ni', 'existing index 0 unchanged by add');
+    assert.equal($('.ember-text-field')[2].value, 'yon', 'existing index 2 unchanged by add');
+    assert.equal($('.ember-text-field')[3].value, '', 'new text field is empty');
     assert.equal($('.btn-success').length, 1);
-})
+});

--- a/tests/integration/components/multiple-textbox-input-test.js
+++ b/tests/integration/components/multiple-textbox-input-test.js
@@ -1,0 +1,39 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('multiple-textbox-input', 'Integration | Component | multiple textbox input', {
+    integration: true,
+    beforeEach() {
+        this.set('textFields', ['ichi', 'ni', 'san', 'yon']);
+    },
+});
+
+test('it renders', function(assert) {
+    this.render(hbs`{{multiple-textbox-input}}`);
+    assert.equal($('.ember-text-field').length, 1, 'one text field by default');
+    assert.equal($('.btn-danger').length, 0, 'no remove button for single text field');
+    assert.equal($('.btn-success').length, 1, 'one add button');
+});
+
+test('it loads passed in fields', function(assert) {
+    this.render(hbs`{{multiple-textbox-input textFields=textFields}}`);
+    assert.equal($('.ember-text-field').length, 4, 'has four text fields when passed in an array of four');
+    assert.equal($('.btn-danger').length, 3, 'has three remove buttons when passed in array of four');
+    assert.equal($('.btn-success').length, 1, 'one add button');
+});
+
+test('Can add and remove fields', function(assert) {
+    this.render(hbs`{{multiple-textbox-input textFields=textFields}}`);
+    this.$('.btn-danger')[0].click();
+    assert.equal($('.ember-text-field').length, 3, 'has three text fields after single remove');
+    assert.equal($('.btn-danger').length, 2, 'has two remove buttons after single remove');
+    assert.equal($('.ember-text-field')[0].value, "ni", 'old index 1 now index 0 after single remove');
+    assert.equal($('.ember-text-field')[2].value, "yon", 'old index 3 now index 2 after single remove');
+    this.$('.btn-success')[0].click();
+    assert.equal($('.ember-text-field').length, 4, 'has 4 text fields after single add');
+    assert.equal($('.btn-danger').length, 3, 'has three remove buttons after single remove');
+    assert.equal($('.ember-text-field')[0].value, "ni", 'existing index 0 unchanged by add');
+    assert.equal($('.ember-text-field')[2].value, "yon", 'existing index 2 unchanged by add');
+    assert.equal($('.ember-text-field')[3].value, "", 'new text field is empty');
+    assert.equal($('.btn-success').length, 1);
+})

--- a/tests/integration/components/multiple-textbox-input-test.js
+++ b/tests/integration/components/multiple-textbox-input-test.js
@@ -10,13 +10,15 @@ moduleForComponent('multiple-textbox-input', 'Integration | Component | multiple
 
 test('it renders', function(assert) {
     this.render(hbs`{{multiple-textbox-input}}`);
+    assert.equal($('.text-fields-legend').text(), 'Text Fields', 'renders default legend');
     assert.equal($('.ember-text-field').length, 1, 'one text field by default');
     assert.equal($('.btn-danger').length, 0, 'no remove button for single text field');
     assert.equal($('.btn-success').length, 1, 'one add button');
 });
 
 test('it loads passed in fields', function(assert) {
-    this.render(hbs`{{multiple-textbox-input textFields=textFields}}`);
+    this.render(hbs`{{multiple-textbox-input textFields=textFields legend='Count in Japanese'}}`);
+    assert.equal($('legend').text(), 'Count in Japanese', 'renders passed in legend');
     assert.equal($('.ember-text-field').length, 4, 'has four text fields when passed in an array of four');
     assert.equal($('.btn-danger').length, 3, 'has three remove buttons when passed in array of four');
     assert.equal($('.btn-success').length, 1, 'one add button');


### PR DESCRIPTION
## Purpose
- Add a component to handle a variable amount of text inputs. Needed for Sloan Signals of Trust feature for users to add links.

## Summary of Changes/Side Effects
- Added component `multiple-textbox-input`
 - takes `placeholder` and `textFields` argument. `textFields` is a string[] that is used to populate this field if there are values already present.

## Testing Notes
- There are some cases where it can remove the wrong textbox, but I'm having trouble narrowing down when/why this happens. And occasionally the `Add` button can get put between the `Remove` buttons, but this is also very sporadic. Not sure how to reproduce.
- Please test when textfields are already populated (i.e.: a user edits a preprint with data links or prereg links already filled out)


## Ticket

https://openscience.atlassian.net/browse/ENG-1435

## Notes for Reviewer
- Please let me know if there are preprints conventions that are not being followed!


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
