### PR TITLE
Center assertions dropdown on mobile

### DIFF
--- a/app/components/assertions-dropdown.js
+++ b/app/components/assertions-dropdown.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 import Analytics from 'ember-osf/mixins/analytics';
 
 export default Component.extend(Analytics, {
@@ -13,6 +14,21 @@ export default Component.extend(Analytics, {
                     action: 'click',
                     label: `Open - ${sloanField}`,
                 });
+        },
+        calculatePosition(...args) {
+            const pos = calculatePosition(...args);
+            const [trigger, content] = args;
+
+            const scroll = { left: window.pageXOffset, top: window.pageYOffset };
+            const viewportWidth = document.body.clientWidth || window.innerWidth;
+            if (viewportWidth < 769) {
+                const { width: dropdownWidth } = content.getBoundingClientRect();
+                const { left: triggerLeft, width: triggerWidth } = trigger.getBoundingClientRect();
+                const triggerLeftWithScroll = triggerLeft + scroll.left;
+                pos.style.left = triggerLeftWithScroll + ((triggerWidth - dropdownWidth) / 2);
+            }
+
+            return pos;
         },
     },
 });

--- a/app/styles/author-assertions.scss
+++ b/app/styles/author-assertions.scss
@@ -47,11 +47,11 @@
 }
 
 .assertions-dropdown-content {
-    width: 340px;
+    max-width: 340px;
     min-height: 50px;
     max-height: 200px;
     padding: 15px 15px 15px 20px;
-    margin-top: 10px;
+    margin-top: 5px;
     border-radius: 2px;
     background-color: #ffffff;
     background-size: cover;

--- a/app/templates/components/assertions-dropdown.hbs
+++ b/app/templates/components/assertions-dropdown.hbs
@@ -1,5 +1,6 @@
 {{#basic-dropdown
     onOpen=(action 'onOpen' assertionName)
+    calculatePosition=(action 'calculatePosition')
     as |dropdown|
 }}
     {{#dropdown.trigger class='assertions-dropdown-trigger'}}


### PR DESCRIPTION
## Purpose
Assertions dropdown overflows on the right for small screens (<769px) 

## Summary of Changes/Side Effects
- On small screens; Use `calculatePosition` 

## Testing Notes
- On the preprint detail, mobile and tablet screens; the dropdown should be centered (just like
everything in the preprint header)

## Ticket

https://openscience.atlassian.net/browse/ENG-

## Notes for Reviewer
- This is easier to accomplish in js compared to css, because the dropdown is (absolutely) positioned by `ember-basic-dropdown`.

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
