### PR TITLE
[LukewarmFix] Make another v2 request on content route

### DIFF
--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -31,30 +31,19 @@ export default Route.extend({
             dataType: 'json',
             contentType: 'application/json',
             xhrFields: {
-                withCredentials: true
-            }
-        }
+                withCredentials: true,
+            },
+        };
 
-        this.get('currentUser').authenticatedAJAX(opts).then(res => {
+        this.get('currentUser').authenticatedAJAX(opts).then((res) => {
             if (Array.isArray(res.meta.active_flags)) {
-                this.get('features').setup(
-                    res.meta.active_flags.reduce(function(acc, flag) {
-                        acc[flag] = true;
-                        return acc;
-                    }, {})
-                )
+                this.get('features').setup(res.meta.active_flags.reduce(function(acc, flag) {
+                    acc[flag] = true;
+                    return acc;
+                }, {}));
             }
-            // Push the result into the store for later use by the current-user service
-            // Note: we have to deepcopy res because pushPayload mutates our data
-            // and causes an infinite loop because reasons
-            if (res['meta']['current_user'] !== null ){
-                this.get('store').pushPayload(Ember.copy(res['meta']['current_user'], true));
-            } else {
-                return Ember.RSVP.reject();
-            }
-            return res['meta']['current_user']['data'];
         });
-        
+
         return this
             .store
             .findRecord('preprint', params.preprint_id);

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -1,6 +1,8 @@
 import { isArray } from '@ember/array';
 import Route from '@ember/routing/route';
 import DS from 'ember-data';
+import { inject as service } from '@ember/service';
+import config from 'ember-get-config';
 
 // Error handling for API
 const handlers = new Map([
@@ -20,7 +22,39 @@ const handlers = new Map([
  * @class Content Route Handler
  */
 export default Route.extend({
+    currentUser: service(),
+    features: service(),
     model(params) {
+        const opts = {
+            method: 'GET',
+            url: `${config.OSF.apiUrl}/${config.OSF.apiNamespace}/`,
+            dataType: 'json',
+            contentType: 'application/json',
+            xhrFields: {
+                withCredentials: true
+            }
+        }
+
+        this.get('currentUser').authenticatedAJAX(opts).then(res => {
+            if (Array.isArray(res.meta.active_flags)) {
+                this.get('features').setup(
+                    res.meta.active_flags.reduce(function(acc, flag) {
+                        acc[flag] = true;
+                        return acc;
+                    }, {})
+                )
+            }
+            // Push the result into the store for later use by the current-user service
+            // Note: we have to deepcopy res because pushPayload mutates our data
+            // and causes an infinite loop because reasons
+            if (res['meta']['current_user'] !== null ){
+                this.get('store').pushPayload(Ember.copy(res['meta']['current_user'], true));
+            } else {
+                return Ember.RSVP.reject();
+            }
+            return res['meta']['current_user']['data'];
+        });
+        
         return this
             .store
             .findRecord('preprint', params.preprint_id);

--- a/tests/unit/routes/content-test.js
+++ b/tests/unit/routes/content-test.js
@@ -6,6 +6,8 @@ moduleFor('route:content', 'Unit | Route | content', {
         'service:metrics',
         'service:theme',
         'service:session',
+        'service:current-user',
+        'service:features',
     ],
 });
 

--- a/tests/unit/routes/provider/content-test.js
+++ b/tests/unit/routes/provider/content-test.js
@@ -8,6 +8,8 @@ moduleFor('route:provider/content', 'Unit | Route | provider/content', {
         'service:metrics',
         'service:theme',
         'service:session',
+        'service:current-user',
+        'service:features',
     ],
 });
 


### PR DESCRIPTION
In the `content` route, we fire an extra `v2` request for the waffle flags because somehow the first request sent upon app initialization doesn't get the correct flags.