### PR TITLE
Fix update bug. Placeholder text should wrap.

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1189,9 +1189,12 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         },
         updateHasDataLinks(value) {
             this.set('hasDataLinks', value);
+            this.set('dataLinks', null);
         },
         updateHasPreregLinks(value) {
             this.set('hasPreregLinks', value);
+            this.set('preregLinks', null);
+            this.set('preregLinkInfo', null);
         },
         updatePreregLinkInfo(value) {
             this.set('preregLinkInfo', value);

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -212,12 +212,13 @@
                                         {{/if}}
                                         {{#if (eq hasDataLinks 'not_applicable')}}
                                             <div class='form-group'>
-                                                <input
+                                                <textarea
                                                     type="text"
                                                     class='form-control'
                                                     disabled
-                                                    placeholder={{t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType}}
                                                 >
+                                                    {{~t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType~}}
+                                                </textarea>
                                             </div>
                                         {{/if}}
                                         <div class="assertionDescription">
@@ -286,12 +287,13 @@
                                         {{/if}}
                                         {{#if (eq hasPreregLinks 'not_applicable')}}
                                             <div class='form-group'>
-                                                <input
+                                                <textarea
                                                     type="text"
                                                     class='form-control'
                                                     disabled
-                                                    placeholder={{t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType}}
                                                 >
+                                                    {{~t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType~}}
+                                                </textarea>
                                             </div>
                                         {{/if}}
                                         <div class="assertionDescription">


### PR DESCRIPTION
## Purpose
Fix the update bug by resetting the fields when user changes options.
Also change from `input` to `textarea` so that the placeholder text will wrap.