### PR TITLE
[No ticket] Disabled  textarea should not be resizable; open link in new tab.

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -969,6 +969,10 @@ hr {
         resize: vertical;
         min-height: 52px;
     }
+
+    textarea:disabled {
+        resize: none;
+    }
 }
 
 #supplemental-materials,

--- a/app/templates/components/assertions-links.hbs
+++ b/app/templates/components/assertions-links.hbs
@@ -1,7 +1,7 @@
 <ul class='assertions-links'>
     {{#each links as |href|}}
         <li>
-            <a href={{href}} onclick={{action 'click' 'link' '{{analyticsName}}'}}>
+            <a href={{href}} target='_blank' rel='noopener' onclick={{action 'click' 'link' '{{analyticsName}}'}}>
                 {{href}}
             </a>
         </li>


### PR DESCRIPTION
## Purpose
In preprint submission workflow, disabled teaxtarea for sloan prereg link and public data should not be resizable.
In preprint detail page, clicking on sloan assertion links should open new tabs.