### PR TITLE
[ENG-1864][ENG-1838] Add helpful error messages when url is invalid. Fix remove save error.

### DIFF
--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -11,7 +11,7 @@ export default Component.extend(Analytics, {
 
     didReceiveAttrs() {
         const valuesFromModel = this.model;
-        if (valuesFromModel.length > 0) {
+        if (valuesFromModel && valuesFromModel.length > 0) {
             this.set('textFields', valuesFromModel.map((value) => {
                 return { value };
             }));

--- a/app/components/multiple-textbox-input.js
+++ b/app/components/multiple-textbox-input.js
@@ -4,21 +4,20 @@ import Analytics from 'ember-osf/mixins/analytics';
 
 export default Component.extend(Analytics, {
     model: null,
-    valuePath: null,
     textFields: null,
     textFieldsLastIndex: computed('textFields.[]', function() {
         return this.get('textFields').length - 1;
     }),
 
     didReceiveAttrs() {
-        const valuesFromModel = this.model.get(this.valuePath);
-        if (valuesFromModel) {
+        const valuesFromModel = this.model;
+        if (valuesFromModel.length > 0) {
             this.set('textFields', valuesFromModel.map((value) => {
                 return { value };
             }));
-            return;
+        } else {
+            this.set('textFields', [{ value: '' }]);
         }
-        this.set('textFields', [{ value: '' }]);
     },
 
     actions: {
@@ -37,7 +36,7 @@ export default Component.extend(Analytics, {
             this.send('onChange');
         },
         onChange() {
-            this.model.set(this.valuePath, this.get('textFields').filter((item) => {
+            this.set('model', this.get('textFields').filter((item) => {
                 if (!item.value) {
                     return false;
                 }

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1466,7 +1466,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
                 model.set('whyNoPrereg', this.get('whyNoPrereg'));
             }
             model.save().then(this._moveFromAuthorAssertions.bind(this))
-                .catch(this._failMoveFromAuthorAssertions.bind(this));
+                .catch(error => this._failMoveFromAuthorAssertions.bind(this)(error));
         },
         discardAuthorAssertions() {
             this.set('hasDataLinks', this.get('model.hasDataLinks'));
@@ -1623,8 +1623,12 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     _moveFromAuthorAssertions() {
         this.send('next', 'Assertions');
     },
-    _failMoveFromAuthorAssertions() {
-        this.get('toast').error(this.get('i18n').t('submit.author_assertions_error'));
+    _failMoveFromAuthorAssertions(error) {
+        if (error.errors[0].detail[0]) {
+            this.get('toast').error(error.errors[0].detail[0]);
+        } else {
+            this.get('toast').error(this.get('i18n').t('submit.author_assertions_error'));
+        }
     },
     _moveFromCoi() {
         this.send('next', 'COI');

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1189,11 +1189,19 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         },
         updateHasDataLinks(value) {
             this.set('hasDataLinks', value);
-            this.set('dataLinks', null);
+            if (value === 'available') {
+                this.set('dataLinks', []);
+            } else {
+                this.set('dataLinks', null);
+            }
         },
         updateHasPreregLinks(value) {
             this.set('hasPreregLinks', value);
-            this.set('preregLinks', null);
+            if (value === 'available') {
+                this.set('preregLinks', []);
+            } else {
+                this.set('preregLinks', null);
+            }
             this.set('preregLinkInfo', null);
         },
         updatePreregLinkInfo(value) {
@@ -1476,6 +1484,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
             this.set('preregLinks', this.get('model.preregLinks'));
             this.set('preregLinkInfo', this.get('model.preregLinkInfo'));
             this.set('whyNoPrereg', this.get('model.whyNoPrereg'));
+
         },
     },
 

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1189,20 +1189,9 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         },
         updateHasDataLinks(value) {
             this.set('hasDataLinks', value);
-            if (value === 'available') {
-                this.set('dataLinks', []);
-            } else {
-                this.set('dataLinks', null);
-            }
         },
         updateHasPreregLinks(value) {
             this.set('hasPreregLinks', value);
-            if (value === 'available') {
-                this.set('preregLinks', []);
-            } else {
-                this.set('preregLinks', null);
-            }
-            this.set('preregLinkInfo', null);
         },
         updatePreregLinkInfo(value) {
             this.set('preregLinkInfo', value);
@@ -1484,7 +1473,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
             this.set('preregLinks', this.get('model.preregLinks'));
             this.set('preregLinkInfo', this.get('model.preregLinkInfo'));
             this.set('whyNoPrereg', this.get('model.whyNoPrereg'));
-
         },
     },
 

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1189,9 +1189,12 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         },
         updateHasDataLinks(value) {
             this.set('hasDataLinks', value);
+            this.set('dataLinks', []);
         },
         updateHasPreregLinks(value) {
             this.set('hasPreregLinks', value);
+            this.set('preregLinks', []);
+            this.set('preregLinkInfo', '');
         },
         updatePreregLinkInfo(value) {
             this.set('preregLinkInfo', value);
@@ -1621,8 +1624,8 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         this.send('next', 'Assertions');
     },
     _failMoveFromAuthorAssertions(error) {
-        if (error.errors[0].detail[0]) {
-            this.get('toast').error(error.errors[0].detail[0]);
+        if (error.errors[0].detail) {
+            this.get('toast').error(error.errors[0].detail);
         } else {
             this.get('toast').error(this.get('i18n').t('submit.author_assertions_error'));
         }

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -194,8 +194,7 @@
                                         <br>
                                         {{#if (eq hasDataLinks 'available')}}
                                             {{#multiple-textbox-input
-                                                model=this
-                                                valuePath='dataLinks'
+                                                model=dataLinks
                                             }}
                                                 {{t 'components.author-assertions.public_data.linksToData'}}: <span class='required' />
                                             {{/multiple-textbox-input}}
@@ -257,8 +256,7 @@
                                         {{#if (eq hasPreregLinks 'available')}}
                                             <div class='form-group'>
                                                 {{#multiple-textbox-input
-                                                    model=this
-                                                    valuePath='preregLinks'
+                                                    model=preregLinks
                                                 }}
                                                     {{t 'components.author-assertions.prereg.links'}}: <span class='required' />
                                                 {{/multiple-textbox-input}}

--- a/tests/integration/components/multiple-textbox-input-test.js
+++ b/tests/integration/components/multiple-textbox-input-test.js
@@ -1,32 +1,31 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 
 moduleForComponent('multiple-textbox-input', 'Integration | Component | multiple textbox input', {
     integration: true,
     beforeEach() {
-        this.set('model', EmberObject.create({ value: null }));
-        this.set('modelWithExistingValues', EmberObject.create({ value: ['ichi', 'ni', 'san', 'yon'] }));
+        this.set('model', []);
+        this.set('modelWithExistingValues', ['ichi', 'ni', 'san', 'yon']);
         this.set('valuePath', 'value');
     },
 });
 
 test('it renders', function(assert) {
-    this.render(hbs`{{multiple-textbox-input model=model valuePath=valuePath}}`);
+    this.render(hbs`{{multiple-textbox-input model=model}}`);
     assert.equal($('.ember-text-field').length, 1, 'one text field by default');
     assert.equal($('.btn-danger').length, 0, 'no remove button for single text field');
     assert.equal($('.btn-success').length, 1, 'one add button');
 });
 
 test('it loads passed in fields', function(assert) {
-    this.render(hbs`{{multiple-textbox-input model=modelWithExistingValues valuePath=valuePath}}`);
+    this.render(hbs`{{multiple-textbox-input model=modelWithExistingValues}}`);
     assert.equal($('.ember-text-field').length, 4, 'has four text fields when passed in an array of four');
     assert.equal($('.btn-danger').length, 3, 'has three remove buttons when passed in array of four');
     assert.equal($('.btn-success').length, 1, 'one add button');
 });
 
 test('Can add and remove fields', function(assert) {
-    this.render(hbs`{{multiple-textbox-input model=modelWithExistingValues valuePath=valuePath}}`);
+    this.render(hbs`{{multiple-textbox-input model=modelWithExistingValues}}`);
     this.$('.btn-danger')[0].click();
     assert.equal($('.ember-text-field').length, 3, 'has three text fields after single remove');
     assert.equal($('.btn-danger').length, 2, 'has two remove buttons after single remove');


### PR DESCRIPTION
## Purpose
This PR do three things:
- Show helpful error messages returned from the backend when the url input for data links/prereg links are invalid.
- Fix various save error due to how we PATCH data.
- Fix "Discard Changes"  not working when removing links.

## Summary of Changes/Side Effects
- Take error from API response and toast that error in `_failMoveFromAuthorAssertions`.
- Modify `multiple-textbox-input` component.
  - Instead of relying on `valuePath`, we directly pass the computed property into the component for updates so that "Discard changes" may work.
- In `updateHasDataLinks` and `updateHasPreregLinks`, we no longer reset `dataLinks`, `preregLinks` and `preregLinkInfo` because the backend doesn't like `null` for those fields.
  - It was suggested that we set `dataLinks` and `preregLinks` to empty arrays, which the backend does accept. However this doesn't work due to an edge case where user clicks `Available` and then `No`, at which point `dataLinks` will be set to `[]` and the backend doesn't accept `"dataLinks": []` when `"hasDataLinks": 'no'`. (I know, this is really messy...)

## Testing Notes
No notes other than trying the previous test cases. May ping me to test together if it makes it easier


## Ticket

https://openscience.atlassian.net/browse/ENG-1864
https://openscience.atlassian.net/browse/ENG-1838

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
