### PR TITLE
[WIP][hotfix][ENG-1964] stop unnecessary keen logging

### DIFF
--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -215,41 +215,11 @@ export default Controller.extend(Analytics, {
             window.open(href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,width=600,height=400');
             return false;
         },
-        // Sends Event to GA/Keen as normal. Sends second event to Keen under
-        // "non-contributor-preprint-downloads" collection to track non contributor
-        // preprint downloads specifically.
-        dualTrackNonContributors(category, label, url, primary) {
-            this.send('click', category, label, url); // Sends event to both Google Analytics and Keen.
-
-            const eventData = {
-                download_info: {
-                    preprint: {
-                        type: 'preprint',
-                        id: this.get('model.id'),
-                    },
-                    file: {
-                        id: primary ? this.get('model.primaryFile.id') : this.get('primaryFile.id'),
-                        primaryFile: primary,
-                        version: primary ? this.get('model.primaryFile.currentVersion') : this.get('primaryFile.currentVersion'),
-                    },
-                },
-                interaction: {
-                    category,
-                    action: 'click',
-                    label: `${label} as Non-Contributor`,
-                    url,
-                },
-            };
-
-            const keenPayload = {
-                collection: 'non-contributor-preprint-downloads',
-                eventData,
-                node: this.get('node'),
-            };
-
-            if (!this.get('userIsContrib')) {
-                this.get('metrics').invoke('trackSpecificCollection', 'Keen', keenPayload); // Sends event to Keen if logged-in user is not a contributor or non-authenticated user
-            }
+        // Sends Event to GA.  Previously sent a second event to Keen to track non-contributor
+        // downloads, but that functionality has been removed.  Stub left in place in case we want
+        // to double-log later.
+        trackNonContributors(category, label, url) {
+            this.send('click', category, label, url);
         },
     },
 

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -99,7 +99,7 @@
                     <div class="col-md-5">
                         {{!SHARE ROW}}
                         <div class="share-row p-sm osf-box-lt clearfix">
-                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'dualTrackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download true}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
+                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'trackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
                             <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
                         </div>
                         <div class="flexbox">

--- a/config/environment.js
+++ b/config/environment.js
@@ -69,21 +69,6 @@ module.exports = function(environment) {
                     version: 'dimension5',
                 },
             },
-            {
-                name: 'Keen',
-                environments: [process.env.KEEN_ENVIRONMENT || 'production'],
-                config: {
-                    private: {
-                        projectId: process.env.PREPRINTS_PRIVATE_PROJECT_ID,
-                        writeKey: process.env.PREPRINTS_PRIVATE_WRITE_KEY,
-                    },
-                    public: {
-                        projectId: process.env.PREPRINTS_PUBLIC_PROJECT_ID,
-                        writeKey: process.env.PREPRINTS_PUBLIC_WRITE_KEY,
-                    },
-                },
-            },
-
         ],
         FB_APP_ID: process.env.FB_APP_ID,
         chronosProviders: [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hotfix": "git flow hotfix start rename-me && npm --no-git-tag-version version patch && git ci package.json -m 'Bump version' && git br -m \"hotfix/$(npm version | head -1 | grep -o '[0-9]\\+\\.[0-9]\\+\\.[0-9]\\+')\""
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#0.30.1",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#0.30.2",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "autoprefixer": "^7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,9 +968,9 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#0.30.1":
-  version "0.30.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#81f3b20c6c2f0c3c42e3fbd33b44d828da71aced"
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#0.30.2":
+  version "0.30.2"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2623f15bae021f96789de9800b22692934048a41"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -1004,10 +1004,7 @@
     ember-sinon-qunit "1.6.0"
     ember-toastr "1.7.0"
     ember-truth-helpers "1.3.0"
-    js-cookie "2.1.4"
-    js-md5 "0.4.2"
     js-yaml "3.8.4"
-    keen-tracking "1.1.3"
     langs "1.0.2"
     moment-timezone "^0.5.13"
     node-sass "4.9.0"
@@ -3898,7 +3895,7 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@1.2.1, component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@1.2.1, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -8002,18 +7999,6 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
 
-js-cookie@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.0.tgz#479c20d0a0bb6cab81491f917788cd025d6452f0"
-
-js-cookie@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.1.4.tgz#da4ec503866f149d164cf25f579ef31015025d8d"
-
-js-md5@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.4.2.tgz#8a1231e60ab392a6d3a75db6d532ec0c59667bc3"
-
 js-reporters@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.1.tgz#f88c608e324a3373a95bcc45ad305e5c979c459b"
@@ -8175,20 +8160,6 @@ jsprim@^1.2.2:
 just-extend@^1.1.27:
   version "1.1.27"
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
-
-keen-core@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/keen-core/-/keen-core-0.1.2.tgz#e8c107fdef227f56e6cf12eb59ef41ff38c37778"
-  dependencies:
-    component-emitter "^1.2.0"
-
-keen-tracking@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/keen-tracking/-/keen-tracking-1.1.3.tgz#1159d2066b90474472fb611ac31c37bc51d94b72"
-  dependencies:
-    component-emitter "^1.2.0"
-    js-cookie "2.1.0"
-    keen-core "0.1.2"
 
 keyv@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
~# NOT YET READY FOR MERGE~

~This needs https://github.com/CenterForOpenScience/ember-osf/pull/450 to be merged and released first.  Then the yarn deps can be updated to replace the second commit.~

## Purpose

Stop logging unused events to keen.  No point in wasting bandwidth for stuff we don't use.

## Summary of Changes/Side Effects

No visible effects.  Stop sending `non-contributor-preprint-downloads` to Keen but continue to send them to GA.  Logging stub function has been left in in case we want to tee these events again later.

## Testing Notes

Will be dev-tested after release.

## Ticket

https://openscience.atlassian.net/browse/ENG-2010

## Notes for Reviewer

- [ ] Have a pleasant day!
- [ ] Achieve your dreams!
- [ ] Teach a duck how to read Linear A!

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] ~~testable and includes test(s)~~ *(changes are delete-only)*
- [ ] ~~changes described in `CHANGELOG.md`~~ *(happy to do this, but not sure how it interacts w/ hotfix workflow)*
