### PR TITLE
[ENG-2057]Add data-test attr to multi-text input wrapping div

### DIFF
--- a/app/templates/components/multiple-textbox-input.hbs
+++ b/app/templates/components/multiple-textbox-input.hbs
@@ -4,8 +4,8 @@
     </legend>
     <div class="row">
         {{#each textFields key="id" as |field index|}}
-            <div class="col-xs-12 p-t-xs text-input-row">
-                {{input data-test-multiple-textbox-input-index=index class="form-control ember-text-field" type="text" placeholder=placeholder value=field.value change=(action 'onChange') }}
+            <div data-test-multiple-textbox-index={{index}} class="col-xs-12 p-t-xs text-input-row">
+                {{input class="form-control ember-text-field" type="text" placeholder=placeholder value=field.value change=(action 'onChange') }}
                 {{#if (and (gt textFields.length 1) (gt textFieldsLastIndex index) )}}
                     <button data-test-multiple-textbox-input-remove={{index}} class="btn btn-danger btn-small" onClick={{action 'removeTextField' index}} aria-label='Remove text field'>{{fa-icon 'minus'}}</button>
                 {{else}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
- Add a data-test attribute so Selenium test can grab HTML elements reliably in testing


## Summary of Changes/Side Effects
- The multiple-text-input used for data availability and prereg links did not have a data-test attr in the previous version. This fix will add the data-test attr (`data-test-multiple-textbox-index={{index}}`) to the wrapping div, so the text input should be accessible by looking for the `<input>` element within this div (the input being used does not allow for data-test attrs to be put on it directly, so this workaround is needed)

## Testing Notes
Please let me know if the text-box is gettable and if any other changes are needed!

## Ticket

https://openscience.atlassian.net/browse/ENG-2057

## Notes for Reviewer
- the ember {{input}} helper does not want to take the `data-test` attrs, so this workaround was done instead. Using vanilla HTML `<input>` would have needed some extra work to ensure the 2-way binding in this case, so the change needing the minimal change was used 


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
