### PR TITLE
[Hotfix] Only show providers that allow submissions on submit page

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1481,7 +1481,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     _setCurrentProvider() {
         this.get('store')
-            .findAll('preprint-provider', { reload: true, adapterOptions: { 'filter[allow_submissions]': 'true' } })
+            .query('preprint-provider', { 'filter[allow_submissions]': true, reload: true })
             .then(this._getProviders.bind(this));
     },
 
@@ -1523,6 +1523,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     },
 
     _getProviders(providers) {
+        console.log('_getProviders -> providers', providers);
         this.set(
             'allProviders',
             // OSF first, then all the rest

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1481,7 +1481,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     _setCurrentProvider() {
         this.get('store')
-            .query('preprint-provider', { 'filter[allow_submissions]': true, reload: true })
+            .findAll('preprint-provider', { adapterOptions: { query: { 'filter[allow_submissions]': true } }, reload: true })
             .then(this._getProviders.bind(this));
     },
 
@@ -1523,7 +1523,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     },
 
     _getProviders(providers) {
-        console.log('_getProviders -> providers', providers);
         this.set(
             'allProviders',
             // OSF first, then all the rest

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1481,7 +1481,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     _setCurrentProvider() {
         this.get('store')
-            .findAll('preprint-provider', { adapterOptions: { query: { 'filter[allow_submissions]': true } }, reload: true })
+            .query('preprint-provider', { filter: { allow_submissions: true } })
             .then(this._getProviders.bind(this));
     },
 

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -1481,7 +1481,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     _setCurrentProvider() {
         this.get('store')
-            .findAll('preprint-provider', { reload: true })
+            .findAll('preprint-provider', { reload: true, adapterOptions: { 'filter[allow_submissions]': 'true' } })
             .then(this._getProviders.bind(this));
     },
 

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -27,7 +27,7 @@ export default Mixin.create({
         if (controller.get('model.isLoaded')) { controller.clearFields(); }
         controller.set('editMode', this.get('editMode'));
 
-        this.get('store').findAll('preprint-provider').then(this._setProviders.bind(this));
+        this.get('store').query('preprint-provider', { 'filter[allow_submissions]': true }).then(this._setProviders.bind(this));
 
         this.get('theme.provider').then(this._getAvailableLicenses.bind(this));
 

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -27,7 +27,7 @@ export default Mixin.create({
         if (controller.get('model.isLoaded')) { controller.clearFields(); }
         controller.set('editMode', this.get('editMode'));
 
-        this.get('store').query('preprint-provider', { 'filter[allow_submissions]': true }).then(this._setProviders.bind(this));
+        this.get('store').findAll('preprint-provider', { adapterOptions: { query: { 'filter[allow_submissions]': true } } }).then(this._setProviders.bind(this));
 
         this.get('theme.provider').then(this._getAvailableLicenses.bind(this));
 

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -27,7 +27,9 @@ export default Mixin.create({
         if (controller.get('model.isLoaded')) { controller.clearFields(); }
         controller.set('editMode', this.get('editMode'));
 
-        this.get('store').findAll('preprint-provider', { adapterOptions: { query: { 'filter[allow_submissions]': true } } }).then(this._setProviders.bind(this));
+        this.get('store')
+            .query('preprint-provider', { filter: { allow_submissions: true } })
+            .then(this._setProviders.bind(this));
 
         this.get('theme.provider').then(this._getAvailableLicenses.bind(this));
 


### PR DESCRIPTION
##  Purpose
Providers that don't allow submissions are shown on the submit page, and that's not right.


## Summary of Changes/Side Effects
- changed `controller/submit.js` to filter on `allow_submissions` when getting the preprint providers
- changed the `findAll` to use `query` instead
- ~~Side effect: the URL for getting the preprint providers has the `filter[allow_submissions]=true` in there twice. Less than ideal, but is taking far too long to debug the issue, so am leaving it be for now. Sorry.~~


## Testing Notes
Please verify that only providers that have `allow_submissions=true` are shown on the submit page. this should still include OSF


## Ticket
`NA`

## Notes for Reviewer
`NA`


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`