### PR TITLE
[HOTFIX] Author assertion dropdown content.

### DIFF
--- a/app/templates/components/author-assertions.hbs
+++ b/app/templates/components/author-assertions.hbs
@@ -63,7 +63,7 @@
                                 links=preprint.preregLinks
                                 analyticsName=(t 'components.author-assertions.prereg.title')
                             }}
-                        {{else if (eq preprint.hasDataLinks 'no')}}
+                        {{else if (eq preprint.hasPreregLinks 'no')}}
                             {{#if preprint.whyNoPrereg}}
                                 {{preprint.whyNoPrereg}}
                             {{else}}


### PR DESCRIPTION
The `Preregistration` section content not looking at the correct attribute on the preprint.