### PR TITLE
[hotfix] correct tracking action name

### DIFF
--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -79,7 +79,7 @@
                                 {{t "content.private_preprint_warning" documentType=model.provider.documentType supportEmail='support@osf.io'}}
                             </div>
                         {{/if}}
-                        {{preprint-file-renderer provider=model.provider preprint=model primaryFile=primaryFile dualTrackNonContributors=(action 'dualTrackNonContributors')}}
+                        {{preprint-file-renderer provider=model.provider preprint=model primaryFile=primaryFile trackNonContributors=(action 'trackNonContributors')}}
                         <div>
                             <span>{{t dateLabel}}: {{moment-format relevantDate "MMMM DD, YYYY"}}</span>
                             {{#if (not isWithdrawn)}}

--- a/tests/integration/components/preprint-file-renderer-test.js
+++ b/tests/integration/components/preprint-file-renderer-test.js
@@ -60,13 +60,13 @@ moduleForComponent('preprint-file-renderer', 'Integration | Component | preprint
             provider: 'osf',
             id: 890,
         });
-        const dualTrackNonContributors = () => {};
+        const trackNonContributors = () => {};
         this.register('service:theme', themeStub);
         this.inject.service('theme');
         this.set('preprint', preprint);
         this.set('versions', fileVersions);
         this.set('primaryFile', file);
-        this.set('dualTrackNonContributors', dualTrackNonContributors);
+        this.set('trackNonContributors', trackNonContributors);
     },
 });
 
@@ -76,7 +76,7 @@ test('it renders', function(assert) {
         preprint=preprint
         primaryFile=primaryFile
         versions=versions
-        dualTrackNonContributors=(action dualTrackNonContributors)
+        trackNonContributors=(action trackNonContributors)
     }}`);
     assert.equal(this.$('.osf-box').length, 0);
     assert.equal(this.$('#selectedFileName').text(), 'test file');
@@ -92,7 +92,7 @@ test('primary file versions exist', function(assert) {
         preprint=preprint
         primaryFile=primaryFile
         versions=versions
-        dualTrackNonContributors=(action dualTrackNonContributors)
+        trackNonContributors=(action trackNonContributors)
     }}`);
     assert.ok($('a.dropdown-toggle')[0].innerText.includes('Download previous versions'));
     assert.ok($('a.dropdown-item')[0].innerText.includes('Version 2'));
@@ -105,7 +105,7 @@ test('primary file one version', function(assert) {
         preprint=preprint
         primaryFile=primaryFile
         versions=versions
-        dualTrackNonContributors=(action dualTrackNonContributors)
+        trackNonContributors=(action trackNonContributors)
     }}`);
     assert.notOk($('a.dropdown-toggle')[0]);
 });


### PR DESCRIPTION
## Purpose

Fix references to renamed tracking function.

## Summary of Changes/Side Effects

In c4e46d4ba4 the analytics tracking method attached to the `preprint-file-renderer` component was renamed from  `dualTrackNonContributors` to `trackNonContributors`.  One instance of the component was updated to use the new name, but another was missed.  This commit fixes that and updates a test that was using the old name.

No side effects expected.

## Testing Notes

None needed?  TBH I'm not sure why this wasn't noticed before.  Could it be vestigial?

## Ticket

No ticket.

## Notes for Reviewer

You are a shining star.

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`
