### PR TITLE
[ENG-1120] Show users full name (including middle name) for preprints detail page

### DIFF
--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -39,7 +39,7 @@
                                         {{else if (user-errors author)}}
                                             <li>{{disabled-user-name author}}</li>
                                         {{else}}
-                                            <li><a href={{author.users.profileURL}} onclick={{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.name}}</a></li>
+                                            <li><a href={{author.users.profileURL}} onclick={{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.fullName}}</a></li>
                                         {{/if}}
                                     {{/if}}
                                 {{~/each}}


### PR DESCRIPTION
## Purpose
- show a user's full name for preprints detail page to keep the displayed name consistent across preprints pages


## Summary of Changes/Side Effects
- show user's `fullName` instead of `user.name` which will only show given name and family name

## Testing Notes
- Please note that whatever name is entered in a user settings "Full name" will be shown in the preprints detail page. A middle name entered in the "Middle name" field will not be shown.
![Screen Shot 2021-04-27 at 4 31 10 PM](https://user-images.githubusercontent.com/51409893/116308819-fc400b80-a775-11eb-8e82-d0888d92d375.png)



## Ticket

https://openscience.atlassian.net/browse/ENG-1120

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
