### PR TITLE
[ENG-2801] Show request error message for failed contributor adds

### DIFF
--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -132,7 +132,11 @@ export default CpPanelBodyComponent.extend(Analytics, {
                     this.highlightSuccessOrFailure(contributor.id, this, 'success');
                 }, (error) => {
                     if (error.errors[0] && error.errors[0].detail) {
-                        this.get('toast').error(error.errors[0].detail);
+                        if (error.errors[0].detail.indexOf('is already a contributor') > -1) {
+                            this.get('toast').error(this.get('i18n').t('submit.error_adding_existing_user'));
+                        } else if (error.errors[0].detail.indexOf('Deactivated users') > -1) {
+                            this.get('toast').error(this.get('i18n').t('submit.error_adding_deactivated_user'));
+                        }
                     } else {
                         this.get('toast').error(this.get('i18n').t('submit.error_adding_unregistered_author'));
                     }

--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -131,7 +131,7 @@ export default CpPanelBodyComponent.extend(Analytics, {
                     ));
                     this.highlightSuccessOrFailure(contributor.id, this, 'success');
                 }, (error) => {
-                    if (error.errors[0] && error.errors[0].detail && error.errors[0].detail.indexOf('is already a contributor') > -1) {
+                    if (error.errors[0] && error.errors[0].detail) {
                         this.get('toast').error(error.errors[0].detail);
                     } else {
                         this.get('toast').error(this.get('i18n').t('submit.error_adding_unregistered_author'));

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -287,6 +287,8 @@ export default {
         preprint_unregistered_author_added: '{{documentType.singularCaptalized}} unregistered author added!',
         error_adding_author: 'Could not add author. Please try again.',
         error_removing_author: 'Could not remove author. Please try again.',
+        error_adding_existing_user: 'User is already a contributor.',
+        error_adding_deactivated_user: 'Deactivated users cannot be added as contributors.',
         error_adding_unregistered_author: 'Could not add unregistered author. Please try again.',
         error_initiating_preprint: 'Could not initiate {{documentType.singular}}. Please try again.',
         error_saving_preprint: 'Could not save {{documentType.singular}}. Please try again.',


### PR DESCRIPTION
## Purpose
- Update the toast message shown when trying to add a user marked as spam.


## Summary of Changes/Side Effects
- Removed a condition that would only show the API error message if users were trying to add a contributor that was already on the preprint. This should allow for the specific API error message to be shown in all cases, unless the API error does not come with a `detail` field.


## Testing Notes
- When adding users by Email, please check that an email that is marked as spam in the admin app will result in a meaningful toast error. Previously it told the user to "Try again," but now it should be a bit more informative.
- Another condition to double check would be when trying to add an email that is already associated with the preprint (ie: user with email address abc@xyz.com is already a contributor, and I try to add a contributor by email that has address abc@xyz.com). This scenario should give a toast error that says that this user is already an author


## Ticket
https://openscience.atlassian.net/browse/ENG-2801

## Notes for Reviewer
- I have opted to just show the error message directly from the API. I wasn't too sure if creating a new translation key for deactivated/spam users and "already is a contributor" would be a better pattern, so feedback on that would be appreciated!


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

