### PR TITLE
[ENG-2946] Make search-facets more accessible

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1254,6 +1254,11 @@ hr {
     text-decoration: underline;
 }
 
+.taxonomy-caret-button {
+    border: none;
+    background: none;
+}
+
 .taxonomy-show-children {
     margin-right: 2px;
 }
@@ -1652,7 +1657,7 @@ nav.branded-navbar {
         word-wrap: break-word;
     }
     .taxonomy-right-padding {
-        padding-right: 14px;
+        padding-right: 23px;
     }
     .taxonomy-left-padding {
         padding-left: 40px;

--- a/app/templates/components/search-facet-taxonomy.hbs
+++ b/app/templates/components/search-facet-taxonomy.hbs
@@ -2,15 +2,13 @@
     <ul>
         {{#each topLevelItem as |item|}}
             <li>
-                <span
-                    role="button"
-                    class="pointer m-r-xs {{if item.showChildren 'taxonomy-show-children'}}"
+                <button
+                    class="pointer m-r-xs taxonomy-caret-button {{if item.showChildren 'taxonomy-show-children'}}"
                     {{action 'expand' item}}
                     aria-label="{{if item.showChildren (t 'global.collapse') (t 'global.expand')}} {{item.text}}"
-                    tabindex=0
                 >
                     <i class="taxonomy-caret fa {{if item.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
-                </span>
+                </button>
                 <label class="taxonomy-checkbox">
                     <input type="checkbox" checked="{{if (if-filter (concat item.shareTitle "|" item.text) state.value) 'checked'}}" onclick={{action updateFilters 'subject' (concat item.shareTitle "|" item.text)}}>
                     {{item.text}}
@@ -21,9 +19,13 @@
                     {{#each item.children as |child|}}
                         <li>
                             {{#if child.childCount }}
-                                <span role="button" class="pointer m-r-xs {{if item.showChildren 'taxonomy-show-children'}}" {{action 'expand' child}}>
+                                <button
+                                    class="pointer m-r-xs taxonomy-caret-button {{if item.showChildren 'taxonomy-show-children'}}"
+                                    {{action 'expand' child}}
+                                    aria-label="{{if child.showChildren (t 'global.collapse') (t 'global.expand')}} {{child.text}}"
+                                >
                                     <i class="taxonomy-caret fa {{if child.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
-                                </span>
+                                </button>
                             {{else}}
                                 <span class="taxonomy-right-padding"></span>
                             {{/if}}


### PR DESCRIPTION
## Purpose
- Make the preprints subjects filtering interface more accessible


## Summary of Changes/Side Effects
- use `<button>` instead of `<span role="button">` for the subjects expand/collapse carets
- add necessary styling

## Testing Notes
- If you are using a screenreader, users should be able to tab into those expand/collapse carets and the screenreader should dictate what subject the user is going to expand/collapse

## Ticket

https://openscience.atlassian.net/browse/ENG-2946

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
