### PR TITLE
[ENG-3016] Remove reliance on sloan flags and switches

### DIFF
--- a/app/components/author-assertions.js
+++ b/app/components/author-assertions.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { alias, and, or } from '@ember/object/computed';
+import { alias, or } from '@ember/object/computed';
 
 export default Component.extend({
     features: service(),
@@ -10,17 +10,12 @@ export default Component.extend({
     provider: alias('preprint.provider'),
     documentType: alias('provider.documentType'),
 
-    shouldShowSloanIcons: and('provider.inSloanStudy', 'hasASloanFlagEnabled', 'hasSloanData'),
-    hasASloanFlagEnabled: or('sloanCoiDisplayEnabled', 'sloanDataDisplayEnabled', 'sloanPreregDisplayEnabled'),
+    shouldShowSloanIcons: alias('hasSloanData'),
     hasSloanData: or('hasCoi', 'hasDataLinks', 'hasPreregLinks'),
 
-    shouldShowCoi: and('hasCoi', 'sloanCoiDisplayEnabled'),
-    shouldShowDataLinks: and('hasDataLinks', 'sloanDataDisplayEnabled'),
-    shouldShowPreregLinks: and('hasPreregLinks', 'sloanPreregDisplayEnabled'),
-
-    sloanCoiDisplayEnabled: alias('features.sloanCoiDisplay'),
-    sloanDataDisplayEnabled: alias('features.sloanDataDisplay'),
-    sloanPreregDisplayEnabled: alias('features.sloanPreregDisplay'),
+    shouldShowCoi: alias('hasCoi'),
+    shouldShowDataLinks: alias('hasDataLinks'),
+    shouldShowPreregLinks: alias('hasPreregLinks'),
 
     hasCoi: computed('preprint.hasCoi', function() {
         return typeof this.preprint.get('hasCoi') === 'boolean';

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -312,15 +312,7 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     moderationType: alias('currentProvider.reviewsWorkflow'),
 
-    _names: computed('shouldShowCoiPanel', 'shouldShowAuthorAssertionsPanel', function() {
-        if (this.get('shouldShowCoiPanel') && !this.get('shouldShowAuthorAssertionsPanel')) {
-            return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
-        }
-        if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {
-            return ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'];
-        }
-        return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'];
-    }),
+    _names: ['Server', 'File', 'Assertions', 'Basics', 'Discipline', 'Authors', 'COI', 'Supplemental'],
 
     // Preprint can be published once all required sections have been saved.
     allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', 'savedAuthorAssertions', function() {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -259,13 +259,6 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
 
     coiStatementValid: alias('validations.attrs.coiStatement.isValid'),
 
-    // Sloan waffles
-    sloanCoiInputEnabled: alias('features.sloanCoiInput'),
-    sloanDataInputEnabled: alias('features.sloanDataInput'),
-    sloanPreregInputEnabled: alias('features.sloanPreregInput'),
-
-    shouldShowCoiPanel: computed.and('sloanCoiInputEnabled', 'currentProvider.inSloanStudy'),
-
     // Basics fields that are being validated are abstract, license and doi
     // (title validated in upload section). If validation
     // added for other fields, expand basicsValid definition.
@@ -298,13 +291,8 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
     savedCoi: computed.notEmpty('model.hasCoi'),
 
     // Does preprint have saved hasDataLinks and hasPreregLinks?
-    savedAuthorAssertions: computed('model.{hasDataLinks,hasPreregLinks}', 'sloanDataInputEnabled', 'sloanPreregInputEnabled', function() {
-        if (this.get('sloanDataInputEnabled') && !this.get('sloanPreregInputEnabled')) {
-            return this.get('model.hasDataLinks');
-        }
-        if (this.get('sloanDataInputEnabled') && this.get('sloanPreregInputEnabled')) {
-            return this.get('model.hasDataLinks') && this.get('model.hasPreregLinks');
-        }
+    savedAuthorAssertions: computed('model.{hasDataLinks,hasPreregLinks}', function() {
+        return this.get('model.hasDataLinks') && this.get('model.hasPreregLinks');
     }),
 
     // Are there any unsaved changes in the upload section?
@@ -334,24 +322,10 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         return ['Server', 'File', 'Basics', 'Discipline', 'Authors', 'Supplemental'];
     }),
 
-    // Variable controlled by sloan waffle flags
-    shouldShowAuthorAssertionsPanel: computed('sloanDataInputEnabled', 'sloanPreregInputEnabled', 'currentProvider.inSloanStudy', function () {
-        if (!this.get('currentProvider.inSloanStudy')) {
-            return false;
-        }
-        return this.get('sloanPreregInputEnabled') || this.get('sloanDataInputEnabled');
-    }),
-
     // Preprint can be published once all required sections have been saved.
     allSectionsValid: computed('savedTitle', 'savedFile', 'savedAbstract', 'savedSubjects', 'authorsValid', 'savedCoi', 'savedAuthorAssertions', function() {
         const allSectionsValid = this.get('savedTitle') && this.get('savedFile') && this.get('savedAbstract') && this.get('savedSubjects') && this.get('authorsValid');
-        if (this.get('shouldShowCoiPanel') && !this.get('shouldShowAuthorAssertionsPanel')) {
-            return allSectionsValid && this.get('savedCoi');
-        }
-        if (this.get('shouldShowCoiPanel') && this.get('shouldShowAuthorAssertionsPanel')) {
-            return allSectionsValid && this.get('savedCoi') && this.get('savedAuthorAssertions');
-        }
-        return allSectionsValid;
+        return allSectionsValid && this.get('savedCoi') && this.get('savedAuthorAssertions');
     }),
 
     supplementalChanged: computed('supplementalProjectTitle', 'pendingSupplementalProjectTitle', 'selectedSupplementalProject', 'node', function() {
@@ -708,13 +682,8 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
         }
         return false;
     }),
-    authorAssertionsValid: computed('publicDataSectionValid', 'preregSectionValid', 'sloanDataInputEnabled', 'sloanPreregInputEnabled', function() {
-        if (this.get('sloanDataInputEnabled') && !this.get('sloanPreregInputEnabled')) {
-            return this.get('publicDataSectionValid');
-        }
-        if (this.get('sloanDataInputEnabled') && this.get('sloanPreregInputEnabled')) {
-            return this.get('publicDataSectionValid') && this.get('preregSectionValid');
-        }
+    authorAssertionsValid: computed('publicDataSectionValid', 'preregSectionValid', function() {
+        return this.get('publicDataSectionValid') && this.get('preregSectionValid');
     }),
 
     actions: {
@@ -1454,17 +1423,15 @@ export default Controller.extend(Analytics, BasicsValidations, COIValidations, N
                     label: `${this.get('editMode') ? 'Edit' : 'Submit'} - Save and Continue Author Assertions Section`,
                 });
             const model = this.get('model');
-            if (this.get('sloanDataInputEnabled')) {
-                model.set('hasDataLinks', this.get('hasDataLinks'));
-                model.set('dataLinks', this.get('dataLinks'));
-                model.set('whyNoData', this.get('whyNoData'));
-            }
-            if (this.get('sloanPreregInputEnabled')) {
-                model.set('hasPreregLinks', this.get('hasPreregLinks'));
-                model.set('preregLinks', this.get('preregLinks'));
-                model.set('preregLinkInfo', this.get('preregLinkInfo'));
-                model.set('whyNoPrereg', this.get('whyNoPrereg'));
-            }
+            model.set('hasDataLinks', this.get('hasDataLinks'));
+            model.set('dataLinks', this.get('dataLinks'));
+            model.set('whyNoData', this.get('whyNoData'));
+
+            model.set('hasPreregLinks', this.get('hasPreregLinks'));
+            model.set('preregLinks', this.get('preregLinks'));
+            model.set('preregLinkInfo', this.get('preregLinkInfo'));
+            model.set('whyNoPrereg', this.get('whyNoPrereg'));
+
             model.save().then(this._moveFromAuthorAssertions.bind(this))
                 .catch(error => this._failMoveFromAuthorAssertions.bind(this)(error));
         },

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -102,54 +102,50 @@
                     {{if (and hasCoi coiStatement) coiStatement (t "submit.body.conflict_of_interest.placeholder")}}
                 </p>
             {{else if (eq name 'Assertions')}}
-                {{#if sloanDataInputEnabled}}
-                    <p> <em class="m-r-md">{{t "components.author-assertions.public_data.title"}}:</em>
-                        {{#if (eq hasDataLinks "available")}}
-                            {{t "components.author-assertions.available.available"}}
-                            {{#each dataLinks as |item|}}
-                                <br>
-                                {{item}}
-                            {{/each}}
+                <p> <em class="m-r-md">{{t "components.author-assertions.public_data.title"}}:</em>
+                    {{#if (eq hasDataLinks "available")}}
+                        {{t "components.author-assertions.available.available"}}
+                        {{#each dataLinks as |item|}}
+                            <br>
+                            {{item}}
+                        {{/each}}
+                    {{/if}}
+                    {{#if (eq hasDataLinks "no")}}
+                        {{t "components.author-assertions.available.no"}}
+                        {{#if whyNoData}}
+                            <br>
+                            {{whyNoData}}
+                        {{else}}
+                            <br>
+                            {{~t 'components.author-assertions.public_data.no'~}}
                         {{/if}}
-                        {{#if (eq hasDataLinks "no")}}
-                            {{t "components.author-assertions.available.no"}}
-                            {{#if whyNoData}}
-                                <br>
-                                {{whyNoData}}
-                            {{else}}
-                                <br>
-                                {{~t 'components.author-assertions.public_data.no'~}}
-                            {{/if}}
+                    {{/if}}
+                    {{#if (eq hasDataLinks "not_applicable")}}
+                        {{t "components.author-assertions.available.not_applicable"}}
+                    {{/if}}
+                </p>
+                <p> <em class="m-r-md">{{t "components.author-assertions.prereg.title"}}:</em>
+                    {{#if (eq hasPreregLinks "available")}}
+                        {{t "components.author-assertions.available.available"}}
+                        {{#each preregLinks as |item|}}
+                            <br>
+                            {{item}}
+                        {{/each}}
+                    {{/if}}
+                    {{#if (eq hasPreregLinks "no")}}
+                        {{t "components.author-assertions.available.no"}}
+                        {{#if whyNoPrereg}}
+                            <br>
+                            {{whyNoPrereg}}
+                        {{else}}
+                            <br>
+                            {{~t 'components.author-assertions.public_data.no'~}}
                         {{/if}}
-                        {{#if (eq hasDataLinks "not_applicable")}}
-                            {{t "components.author-assertions.available.not_applicable"}}
-                        {{/if}}
-                    </p>
-                {{/if}}
-                {{#if sloanPreregInputEnabled}}
-                    <p> <em class="m-r-md">{{t "components.author-assertions.prereg.title"}}:</em>
-                        {{#if (eq hasPreregLinks "available")}}
-                            {{t "components.author-assertions.available.available"}}
-                            {{#each preregLinks as |item|}}
-                                <br>
-                                {{item}}
-                            {{/each}}
-                        {{/if}}
-                        {{#if (eq hasPreregLinks "no")}}
-                            {{t "components.author-assertions.available.no"}}
-                            {{#if whyNoPrereg}}
-                                <br>
-                                {{whyNoPrereg}}
-                            {{else}}
-                                <br>
-                                {{~t 'components.author-assertions.public_data.no'~}}
-                            {{/if}}
-                        {{/if}}
-                        {{#if (eq hasPreregLinks "not_applicable")}}
-                            {{t "components.author-assertions.available.not_applicable"}}
-                        {{/if}}
-                    </p>
-                {{/if}}
+                    {{/if}}
+                    {{#if (eq hasPreregLinks "not_applicable")}}
+                        {{t "components.author-assertions.available.not_applicable"}}
+                    {{/if}}
+                </p>
             {{/if}}
         {{/if}}
 

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -135,182 +135,178 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#if shouldShowAuthorAssertionsPanel}}
-                        {{#with "Assertions" as |name|}}
-                            {{#preprint-form-section
-                                id="author-assertions"
+                
+                    {{#with "Assertions" as |name|}}
+                        {{#preprint-form-section
+                            id="author-assertions"
+                            editMode=editMode
+                            name=name
+                            allowOpen=uploadValid
+                            canEdit=canEdit
+                            errorAction=(action 'error')
+                            as |hasOpened|
+                        }}
+                            {{preprint-form-header
                                 editMode=editMode
+                                assertionsSaveState=assertionsSaveState
+                                hasDataLinks=model.hasDataLinks
+                                dataLinks=model.dataLinks
+                                whyNoData=model.whyNoData
+                                hasPreregLinks=model.hasPreregLinks
+                                preregLinks=model.preregLinks
+                                whyNoPrereg=model.whyNoPrereg
                                 name=name
-                                allowOpen=uploadValid
-                                canEdit=canEdit
-                                errorAction=(action 'error')
-                                as |hasOpened|
+                                valid=authorAssertionsValid
+                                isValidationActive=hasOpened
                             }}
-                                {{preprint-form-header
-                                    editMode=editMode
-                                    assertionsSaveState=assertionsSaveState
-                                    sloanPreregInputEnabled=sloanPreregInputEnabled
-                                    sloanDataInputEnabled=sloanDataInputEnabled
-                                    hasDataLinks=model.hasDataLinks
-                                    dataLinks=model.dataLinks
-                                    whyNoData=model.whyNoData
-                                    hasPreregLinks=model.hasPreregLinks
-                                    preregLinks=model.preregLinks
-                                    whyNoPrereg=model.whyNoPrereg
-                                    name=name
-                                    valid=authorAssertionsValid
-                                    isValidationActive=hasOpened
-                                }}
-                                {{#preprint-form-body class="sloan-assertions"}}
-                                    {{#if sloanDataInputEnabled}}
-                                        <div role='radiogroup'>
-                                            <label>{{t "components.author-assertions.public_data.title"}}: <span class='required' /></label>
-                                            <input
-                                                type="radio"
-                                                id="hasDataLinksAvailable"
-                                                name="hasDataLinks"
-                                                onchange={{action "updateHasDataLinks" "available"}}
-                                                checked={{eq hasDataLinks "available"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasDataLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
-                                            <input
-                                                type="radio"
-                                                id="hasDataLinksNo"
-                                                name="hasDataLinks"
-                                                onchange={{action "updateHasDataLinks" "no"}}
-                                                checked={{eq hasDataLinks "no"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasDataLinksNo">{{t "components.author-assertions.available.no"}}</label>
-                                            <input
-                                                type="radio"
-                                                id="hasDataLinksNotApplicable"
-                                                name="hasDataLinks"
-                                                onchange={{action "updateHasDataLinks" "not_applicable"}}
-                                                checked={{eq hasDataLinks "not_applicable"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasDataLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
-                                        </div>
-                                        <br>
-                                        {{#if (eq hasDataLinks 'available')}}
-                                            <div data-test-data-links-available>
-                                                {{#multiple-textbox-input
-                                                    model=dataLinks
-                                                }}
-                                                    {{t 'components.author-assertions.public_data.linksToData'}}: <span class='required' />
-                                                {{/multiple-textbox-input}}
-                                            </div>
-                                        {{/if}}
-                                        {{#if (eq hasDataLinks 'no')}}
-                                            <label>{{t 'components.author-assertions.describe'}}:</label>
-                                            {{validated-input
-                                                id='whyNoData'
-                                                inputType='textarea'
-                                                model=this
-                                                valuePath='whyNoData'
-                                                value=whyNoData
-                                            }}
-                                        {{/if}}
-                                        {{#if (eq hasDataLinks 'not_applicable')}}
-                                            <div data-test-data-links-not-applicable class='form-group'>
-                                                <textarea
-                                                    type="text"
-                                                    class='form-control'
-                                                    disabled
-                                                >
-                                                    {{~t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType~}}
-                                                </textarea>
-                                            </div>
-                                        {{/if}}
-                                        <div class="assertionDescription">
-                                            {{t "components.author-assertions.public_data.description" documentType=currentProvider.documentType}}
-                                        </div>
-                                    {{/if}}
-                                    {{#if sloanPreregInputEnabled}}
-                                        <div role='radiogroup'>
-                                            <label>{{t "components.author-assertions.prereg.title"}}: <span class='required' /></label>
-                                            <input
-                                                type="radio"
-                                                id="hasPreregLinksAvailable"
-                                                name="hasPreregLinks"
-                                                onchange={{action "updateHasPreregLinks" "available"}}
-                                                checked={{eq hasPreregLinks "available"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasPreregLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
-                                            <input
-                                                type="radio"
-                                                id="hasPreregLinksNo"
-                                                name="hasPreregLinks"
-                                                onchange={{action "updateHasPreregLinks" "no"}}
-                                                checked={{eq hasPreregLinks "no"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasPreregLinksNo">{{t "components.author-assertions.available.no"}}</label>
-                                            <input
-                                                type="radio"
-                                                id="hasPreregLinksNotApplicable"
-                                                name="hasPreregLinks"
-                                                onchange={{action "updateHasPreregLinks" "not_applicable"}}
-                                                checked={{eq hasPreregLinks "not_applicable"}}
-                                            >
-                                            <label class="radioButtonLabel" for="hasPreregLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
-                                        </div>
-                                        <br>
-                                        {{#if (eq hasPreregLinks 'available')}}
-                                            <div data-test-prereg-links-available class='form-group'>
-                                                {{#multiple-textbox-input
-                                                    model=preregLinks
-                                                }}
-                                                    {{t 'components.author-assertions.prereg.links'}}: <span class='required' />
-                                                {{/multiple-textbox-input}}
-                                                <label for="preregLinkInfo">{{t 'components.author-assertions.prereg.type'}}: <span class='required' /></label>
-                                                {{#power-select
-                                                    options=preregLinkInfoChoices
-                                                    placeholder=(t 'components.author-assertions.prereg.chooseOne')
-                                                    selected=preregLinkInfo
-                                                    onchange=(action "updatePreregLinkInfo")
-                                                    searchEnabled=false
-                                                    as |option|
-                                                }}
-                                                    <strong>{{t (concat 'components.author-assertions.prereg.' option)}}</strong>
-                                                {{/power-select}}
-                                            </div>
-                                        {{/if}}
-                                        {{#if (eq hasPreregLinks 'no')}}
-                                            <label>{{t 'components.author-assertions.describe'}}:</label>
-                                            {{validated-input
-                                                id='whyNoPrereg'
-                                                inputType='textarea'
-                                                model=this
-                                                valuePath='whyNoPrereg'
-                                                value=whyNoPrereg
-                                            }}
-                                        {{/if}}
-                                        {{#if (eq hasPreregLinks 'not_applicable')}}
-                                            <div data-test-prereg-links-not-applicable class='form-group'>
-                                                <textarea
-                                                    type="text"
-                                                    class='form-control'
-                                                    disabled
-                                                >
-                                                    {{~t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType~}}
-                                                </textarea>
-                                            </div>
-                                        {{/if}}
-                                        <div class="assertionDescription">
-                                            {{t "components.author-assertions.prereg.description" documentType=currentProvider.documentType}}
-                                        </div>
-                                    {{/if}}
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <div class="pull-right">
-                                                <button {{action 'discardAuthorAssertions'}} data-test-author-assertions-discard class="btn btn-default" disabled={{unless authorAssertionsChanged true}} >{{t "global.discard"}}</button>
-                                                <button {{action 'saveAuthorAssertions'}} data-test-author-assertions-continue class="btn btn-primary" disabled={{unless authorAssertionsValid true}} >{{t "submit.body.save_continue"}}</button>
-                                            </div>
+                            {{#preprint-form-body class="sloan-assertions"}}
+                                
+                                <div role='radiogroup'>
+                                    <label>{{t "components.author-assertions.public_data.title"}}: <span class='required' /></label>
+                                    <input
+                                        type="radio"
+                                        id="hasDataLinksAvailable"
+                                        name="hasDataLinks"
+                                        onchange={{action "updateHasDataLinks" "available"}}
+                                        checked={{eq hasDataLinks "available"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasDataLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="hasDataLinksNo"
+                                        name="hasDataLinks"
+                                        onchange={{action "updateHasDataLinks" "no"}}
+                                        checked={{eq hasDataLinks "no"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasDataLinksNo">{{t "components.author-assertions.available.no"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="hasDataLinksNotApplicable"
+                                        name="hasDataLinks"
+                                        onchange={{action "updateHasDataLinks" "not_applicable"}}
+                                        checked={{eq hasDataLinks "not_applicable"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasDataLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
+                                </div>
+                                <br>
+                                {{#if (eq hasDataLinks 'available')}}
+                                    <div data-test-data-links-available>
+                                        {{#multiple-textbox-input
+                                            model=dataLinks
+                                        }}
+                                            {{t 'components.author-assertions.public_data.linksToData'}}: <span class='required' />
+                                        {{/multiple-textbox-input}}
+                                    </div>
+                                {{/if}}
+                                {{#if (eq hasDataLinks 'no')}}
+                                    <label>{{t 'components.author-assertions.describe'}}:</label>
+                                    {{validated-input
+                                        id='whyNoData'
+                                        inputType='textarea'
+                                        model=this
+                                        valuePath='whyNoData'
+                                        value=whyNoData
+                                    }}
+                                {{/if}}
+                                {{#if (eq hasDataLinks 'not_applicable')}}
+                                    <div data-test-data-links-not-applicable class='form-group'>
+                                        <textarea
+                                            type="text"
+                                            class='form-control'
+                                            disabled
+                                        >
+                                            {{~t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType~}}
+                                        </textarea>
+                                    </div>
+                                {{/if}}
+                                <div class="assertionDescription">
+                                    {{t "components.author-assertions.public_data.description" documentType=currentProvider.documentType}}
+                                </div>
+                                
+                                <div role='radiogroup'>
+                                    <label>{{t "components.author-assertions.prereg.title"}}: <span class='required' /></label>
+                                    <input
+                                        type="radio"
+                                        id="hasPreregLinksAvailable"
+                                        name="hasPreregLinks"
+                                        onchange={{action "updateHasPreregLinks" "available"}}
+                                        checked={{eq hasPreregLinks "available"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasPreregLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="hasPreregLinksNo"
+                                        name="hasPreregLinks"
+                                        onchange={{action "updateHasPreregLinks" "no"}}
+                                        checked={{eq hasPreregLinks "no"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasPreregLinksNo">{{t "components.author-assertions.available.no"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="hasPreregLinksNotApplicable"
+                                        name="hasPreregLinks"
+                                        onchange={{action "updateHasPreregLinks" "not_applicable"}}
+                                        checked={{eq hasPreregLinks "not_applicable"}}
+                                    >
+                                    <label class="radioButtonLabel" for="hasPreregLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
+                                </div>
+                                <br>
+                                {{#if (eq hasPreregLinks 'available')}}
+                                    <div data-test-prereg-links-available class='form-group'>
+                                        {{#multiple-textbox-input
+                                            model=preregLinks
+                                        }}
+                                            {{t 'components.author-assertions.prereg.links'}}: <span class='required' />
+                                        {{/multiple-textbox-input}}
+                                        <label for="preregLinkInfo">{{t 'components.author-assertions.prereg.type'}}: <span class='required' /></label>
+                                        {{#power-select
+                                            options=preregLinkInfoChoices
+                                            placeholder=(t 'components.author-assertions.prereg.chooseOne')
+                                            selected=preregLinkInfo
+                                            onchange=(action "updatePreregLinkInfo")
+                                            searchEnabled=false
+                                            as |option|
+                                        }}
+                                            <strong>{{t (concat 'components.author-assertions.prereg.' option)}}</strong>
+                                        {{/power-select}}
+                                    </div>
+                                {{/if}}
+                                {{#if (eq hasPreregLinks 'no')}}
+                                    <label>{{t 'components.author-assertions.describe'}}:</label>
+                                    {{validated-input
+                                        id='whyNoPrereg'
+                                        inputType='textarea'
+                                        model=this
+                                        valuePath='whyNoPrereg'
+                                        value=whyNoPrereg
+                                    }}
+                                {{/if}}
+                                {{#if (eq hasPreregLinks 'not_applicable')}}
+                                    <div data-test-prereg-links-not-applicable class='form-group'>
+                                        <textarea
+                                            type="text"
+                                            class='form-control'
+                                            disabled
+                                        >
+                                            {{~t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType~}}
+                                        </textarea>
+                                    </div>
+                                {{/if}}
+                                <div class="assertionDescription">
+                                    {{t "components.author-assertions.prereg.description" documentType=currentProvider.documentType}}
+                                </div>
+                                
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="pull-right">
+                                            <button {{action 'discardAuthorAssertions'}} data-test-author-assertions-discard class="btn btn-default" disabled={{unless authorAssertionsChanged true}} >{{t "global.discard"}}</button>
+                                            <button {{action 'saveAuthorAssertions'}} data-test-author-assertions-continue class="btn btn-primary" disabled={{unless authorAssertionsValid true}} >{{t "submit.body.save_continue"}}</button>
                                         </div>
                                     </div>
-                                {{/preprint-form-body}}
-                            {{/preprint-form-section}}
-                        {{/with}}
-                    {{/if}}
+                                </div>
+                            {{/preprint-form-body}}
+                        {{/preprint-form-section}}
+                    {{/with}}
 
                     {{#with "Basics" as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -411,56 +407,55 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                    {{#if shouldShowCoiPanel}}
-                        {{#with "COI" as |name|}}
-                            {{#preprint-form-section id="preprint-form-coi" class="sloan-assertions" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                                {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
-                                {{#preprint-form-body}}
-                                    <div role='radiogroup'>
-                                        <input
-                                            type="radio"
-                                            id="coiYes"
-                                            name="coi"
-                                            value="Yes"
-                                            onchange={{action "updateHasCoi" true}}
-                                            checked={{eq hasCoi true}}
-                                        >
-                                        <label class="radioButtonLabel" for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
-                                        <input
-                                            type="radio"
-                                            id="coiNo"
-                                            name="coi"
-                                            value="No"
-                                            onchange={{action "updateHasCoi" false}}
-                                            checked={{eq hasCoi false}}
-                                        >
-                                        <label class="radioButtonLabel" for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
-                                        <span class='required' />
+                
+                    {{#with "COI" as |name|}}
+                        {{#preprint-form-section id="preprint-form-coi" class="sloan-assertions" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
+                            {{#preprint-form-body}}
+                                <div role='radiogroup'>
+                                    <input
+                                        type="radio"
+                                        id="coiYes"
+                                        name="coi"
+                                        value="Yes"
+                                        onchange={{action "updateHasCoi" true}}
+                                        checked={{eq hasCoi true}}
+                                    >
+                                    <label class="radioButtonLabel" for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
+                                    <input
+                                        type="radio"
+                                        id="coiNo"
+                                        name="coi"
+                                        value="No"
+                                        onchange={{action "updateHasCoi" false}}
+                                        checked={{eq hasCoi false}}
+                                    >
+                                    <label class="radioButtonLabel" for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
+                                    <span class='required' />
+                                </div>
+                                <br>
+                                {{#if hasCoi}}
+                                    <label for='coiStatement'>{{t "submit.body.conflict_of_interest.describe"}} <span class='required' /></label>
+                                    {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
+                                {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
+                                    <div data-test-has-no-coi class='form-group'>
+                                        <input type="text" class='form-control' disabled placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
                                     </div>
-                                    <br>
-                                    {{#if hasCoi}}
-                                        <label for='coiStatement'>{{t "submit.body.conflict_of_interest.describe"}} <span class='required' /></label>
-                                        {{validated-input id='coiStatement' inputType='textarea' model=this valuePath='coiStatement' documentType=currentProvider.documentType value=coiStatement}}
-                                    {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
-                                        <div data-test-has-no-coi class='form-group'>
-                                            <input type="text" class='form-control' disabled placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                                {{/if}}
+                                <div class="assertionDescription">
+                                    {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="pull-right">
+                                            <button {{action 'discardCoi'}} data-test-coi-discard class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
+                                            <button {{action 'saveCoi'}} data-test-coi-continue class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
                                         </div>
-                                    {{/if}}
-                                    <div class="assertionDescription">
-                                        {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
                                     </div>
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <div class="pull-right">
-                                                <button {{action 'discardCoi'}} data-test-coi-discard class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
-                                                <button {{action 'saveCoi'}} data-test-coi-continue class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                {{/preprint-form-body}}
-                            {{/preprint-form-section}}
-                        {{/with}}
-                    {{/if}}
+                                </div>
+                            {{/preprint-form-body}}
+                        {{/preprint-form-section}}
+                    {{/with}}
 
                     {{#with "Supplemental" as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -598,12 +593,8 @@
                                         <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                         <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
                                         <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
-                                        {{#if shouldShowCoiPanel}}
-                                            <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
-                                        {{/if}}
-                                        {{#if shouldShowAuthorAssertionsPanel}}
-                                            <p class="text-danger">{{unless savedAuthorAssertions (t "components.preprint-form-header.name.Assertions")}}</p>
-                                        {{/if}}
+                                        <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
+                                        <p class="text-danger">{{unless savedAuthorAssertions (t "components.preprint-form-header.name.Assertions")}}</p>
                                     </span>
                                 {{/if}}
                                 <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -99,7 +99,7 @@ test('Initial properties', function (assert) {
         '_State.EXISTING': 'existing',
         filePickerState: 'start',
         supplementalPickerState: 'start',
-        '_names.length': 6,
+        '_names.length': 8,
         user: null,
         'availableLicenses.length': 0,
         node: null,
@@ -136,8 +136,8 @@ test('Initial properties', function (assert) {
     const actual = ctrl.getProperties(propKeys);
 
     propKeys.forEach(key => assert.strictEqual(
-        expected[key],
         actual[key],
+        expected[key],
         `Initial value for "${key}" does not match expected value`,
     ));
 });

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -291,17 +291,21 @@ test('savedSubjects computed property', function(assert) {
 
 test('allSectionsValid computed property', function(assert) {
     const ctrl = this.subject();
-    assert.equal(ctrl.get('allSectionsValid'), false);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Nothing set - should be false');
     ctrl.set('savedTitle', true);
-    assert.equal(ctrl.get('allSectionsValid'), false);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Title set - should be false');
     ctrl.set('savedFile', true);
-    assert.equal(ctrl.get('allSectionsValid'), false);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'File saved - should be false');
     ctrl.set('savedAbstract', true);
-    assert.equal(ctrl.get('allSectionsValid'), false);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Abstract saved - should be false');
     ctrl.set('savedSubjects', true);
-    assert.equal(ctrl.get('allSectionsValid'), false);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Subjects saved - should be false');
     ctrl.set('authorsValid', true);
-    assert.equal(ctrl.get('allSectionsValid'), true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Authors valid - should be false');
+    ctrl.set('savedAuthorAssertions', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Author assertions saved - should be false');
+    ctrl.set('savedCoi', true);
+    assert.equal(ctrl.get('allSectionsValid'), true, 'COI saved - should be true');
 });
 
 test('preprintFileChanged computed property', function(assert) {


### PR DESCRIPTION
## Purpose
Remove unnecessary sloan flags from codebase, because clean code is happy code.


## Summary of Changes/Side Effects
1. Simplify computeds relying on sloan flags
2. Remove if statements in templates relying on sloan flags
3. Fix test


## Testing Notes
The whole sloan process from adding information to showing it on the preprint could be affected. Will need to be verified with all the sloan flags and switches turned off once the backend supports it.


## Ticket

https://openscience.atlassian.net/browse/ENG-3016

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
