### PR TITLE
[ENG-2977] Make colors more contrasty on the preprint submit/edit page

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -17,6 +17,11 @@
 
 
 /* GLOBAL to PREPRINTS, these may be used in multiple pages */
+
+.ember-text-field::placeholder {
+    color: #757575;
+}
+
 .pointer {
     cursor: pointer;
 }
@@ -622,7 +627,7 @@ $color-border-light: #DDDDDD;
         color: #444;
         font-size: 15px;
         i {
-            color: #888;
+            color: rgb(51, 51, 51);
             display: block;
         }
         .abstract {
@@ -970,7 +975,7 @@ hr {
 .sloan-assertions {
     span.required:after {
         content: "(required)";
-        color: lighten(red, 30%);
+        color: #e50000;
         font-weight: normal;
         margin-left: 5px;
     }
@@ -1012,7 +1017,7 @@ hr {
 #preprint-form-basics {
     span.required:after {
         content: "(required)";
-        color: lighten(red, 30%);
+        color: #e50000;
         font-weight: normal;
         float: right;
     }

--- a/app/styles/validated-input.scss
+++ b/app/styles/validated-input.scss
@@ -2,7 +2,7 @@
     font-size:12px;
 }
 .validated-input .input-error .error {
-    color: #ff411f;
+    color: #e50000;
 }
 
 .validated-input .valid-input {


### PR DESCRIPTION
## Purpose
Fixes the accessibility problems related to contrast on the Preprints submit/edit page. Some of these changes (`(required)` red in the license picker items) are in https://github.com/CenterForOpenScience/ember-osf/pull/456 but this PR isn't pinned to that, as another preprints PR is already pinned.

## Summary of Changes/Side Effects
1. Darker black for the preprint header preview `<i>` tag
<img width="128" alt="Screen Shot 2021-09-02 at 3 57 49 PM" src="https://user-images.githubusercontent.com/6599111/131908157-74ac231e-421c-40f8-bb07-c550d167389b.png">

2. Darker red for `(required)` and error messages
<img width="171" alt="Screen Shot 2021-09-02 at 3 58 03 PM" src="https://user-images.githubusercontent.com/6599111/131908201-205b5081-09a5-427a-8eb2-21737a858a92.png">
<img width="369" alt="Screen Shot 2021-09-02 at 3 57 56 PM" src="https://user-images.githubusercontent.com/6599111/131908202-354358ce-d6c0-4ece-b6ed-4c6c89789fb4.png">

3. Darker placeholder text
<img width="243" alt="Screen Shot 2021-09-02 at 3 59 20 PM" src="https://user-images.githubusercontent.com/6599111/131908243-146a09b3-4faa-4dc3-9723-62f97d858fef.png">


## Testing Notes
Should just need to make sure that above items are passing a11y guidelines.

## Ticket

https://openscience.atlassian.net/browse/ENG-2977

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
