### PR TITLE
[ENG-2976] More a11y fixes for preprint submit page

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -319,6 +319,9 @@ export default {
         successfully_withdrawn: 'Your {{documentType.singular}} has been successfully withdrawn.',
     },
     components: {
+        'provider-carousel': {
+            select_service: 'Select service',
+        },
         'confirm-share-preprint': {
             body: 'Once this {{documentType.singular}} is made public, you should assume that it will always be public. Even if you delete it, search engines or others may access the files before you do so.',
             title: {
@@ -367,6 +370,7 @@ export default {
         'file-uploader': {
             dropzone_message: 'Drop {{documentType.singular}} file here to upload',
             title_placeholder: 'Enter {{documentType.singular}} title',
+            title_label: 'Title',
             update_version: 'Update {{documentType.singular}} file version.',
             could_not_create_preprint: 'Could not create preprint. Please try again.',
             could_not_update_title: 'Could not update title. Please try again.',

--- a/app/templates/components/file-uploader.hbs
+++ b/app/templates/components/file-uploader.hbs
@@ -11,9 +11,11 @@
         maxfilesexceeded=(action 'maxfilesexceeded')
     }}
     {{#if hasFile}}
-        <form onchange={{action 'track' 'input' 'onchange' 'Submit - Add title, Upload new preprint'}} role="button">
+        {{!-- template-lint-disable no-invalid-interactive --}}
+        <form onchange={{action 'track' 'input' 'onchange' 'Submit - Add title, Upload new preprint'}}>
             {{preprint-title-editor documentType=provider.documentType title=title titleValid=titleValid pressSubmit=(action 'createPreprintAndUploadFile')}}
         </form>
+        {{!-- template-lint-enable no-invalid-interactive --}}
     {{/if}}
 
     <div class="p-t-xs pull-right">

--- a/app/templates/components/preprint-title-editor.hbs
+++ b/app/templates/components/preprint-title-editor.hbs
@@ -1,1 +1,4 @@
-{{validated-input model=this valuePath='title' placeholder=(t "components.file-uploader.title_placeholder" documentType=documentType) value=title pressSubmit=pressSubmit input=(action "isValid")}}
+<label>
+    {{t "components.file-uploader.title_label"}}:
+    {{validated-input model=this valuePath='title' placeholder=(t "components.file-uploader.title_placeholder" documentType=documentType) value=title pressSubmit=pressSubmit input=(action "isValid")}}
+</label>

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -1,6 +1,6 @@
 {{!Provider Carousel}}
 <div id="providerCarousel" class="carousel slide" data-ride="carousel" data-interval="false">
-    <div class="carousel-inner" role="listbox">
+    <div class="carousel-inner" role="listbox" aria-label={{t 'components.provider-carousel.select_service'}}>
         {{#each slides as |slide index|}}
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -202,14 +202,16 @@
                                             </div>
                                         {{/if}}
                                         {{#if (eq hasDataLinks 'no')}}
-                                            <label>{{t 'components.author-assertions.describe'}}:</label>
-                                            {{validated-input
-                                                id='whyNoData'
-                                                inputType='textarea'
-                                                model=this
-                                                valuePath='whyNoData'
-                                                value=whyNoData
-                                            }}
+                                            <label>
+                                                {{t 'components.author-assertions.describe'}}:
+                                                {{validated-input
+                                                    id='whyNoData'
+                                                    inputType='textarea'
+                                                    model=this
+                                                    valuePath='whyNoData'
+                                                    value=whyNoData
+                                                }}
+                                            </label>
                                         {{/if}}
                                         {{#if (eq hasDataLinks 'not_applicable')}}
                                             <div data-test-data-links-not-applicable class='form-group'>
@@ -277,14 +279,16 @@
                                             </div>
                                         {{/if}}
                                         {{#if (eq hasPreregLinks 'no')}}
-                                            <label>{{t 'components.author-assertions.describe'}}:</label>
-                                            {{validated-input
-                                                id='whyNoPrereg'
-                                                inputType='textarea'
-                                                model=this
-                                                valuePath='whyNoPrereg'
-                                                value=whyNoPrereg
-                                            }}
+                                            <label>
+                                                {{t 'components.author-assertions.describe'}}:
+                                                {{validated-input
+                                                    id='whyNoPrereg'
+                                                    inputType='textarea'
+                                                    model=this
+                                                    valuePath='whyNoPrereg'
+                                                    value=whyNoPrereg
+                                                }}
+                                            </label>
                                         {{/if}}
                                         {{#if (eq hasPreregLinks 'not_applicable')}}
                                             <div data-test-prereg-links-not-applicable class='form-group'>
@@ -327,10 +331,12 @@
                                 <div class="row">
                                     <div class="col-md-6">
                                         <div>
-                                            <label>{{t "submit.body.basics.doi.label"}}:</label>
                                             {{!-- template-lint-disable no-invalid-interactive --}}
                                             <form onchange={{action 'stripDOI'}} onsubmit={{action 'preventDefault'}}>
-                                                {{validated-input model=this valuePath='basicsDOI' placeholder=(t "global.doi") value=basicsDOI pressSubmit=(action 'saveBasics')}}
+                                                <label>
+                                                    {{t "submit.body.basics.doi.label"}}:
+                                                    {{validated-input model=this valuePath='basicsDOI' placeholder=(t "global.doi") value=basicsDOI pressSubmit=(action 'saveBasics')}}
+                                                </label>
                                             </form>
                                             {{!-- template-lint-enable no-invalid-interactive --}}
                                         </div>


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Some more accessibility problems were found on the preprints submit page. This fixes those.


## Summary of Changes/Side Effects
1. Added new strings to translation file for use in labels
2. Removed invalid `role='button'` from the form around the preprint title editor and disabled linter from complaining
3. Added aria-label to the provider carousel
4. Wrapped label around the Why No Data text box
5. Wrapped label around the Why No Prereg text box
6. Wrapped label around the DOI input box
7. Added label to the preprint title editor


<img width="796" alt="Screen Shot 2021-10-18 at 9 58 54 AM" src="https://user-images.githubusercontent.com/6599111/137779214-10ef46b9-7590-4dd9-90bc-066cdb5d5865.png">

## Testing Notes
Everything should still be working, so just accessibility testing.


## Ticket

https://openscience.atlassian.net/browse/ENG-2976

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
