### PR TITLE
[ENG-3344] Ensure withdrawn tags have contrast override

### DIFF
--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -285,7 +285,7 @@
                         {{/each}}
                     </div>
 
-                    <div class="p-t-xs">
+                    <div class="tag-section p-t-xs">
                         <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
                         {{#if hasTag}}
                             {{#each model.tags as |tag|}}


### PR DESCRIPTION
## Purpose
Tags on a withdrawn preprint did not have the same contrast as tags on a public preprint. This fixes that so that they both have enough contrast.


## Summary of Changes/Side Effects
1. Ensured that the withdrawn tags were in the proper css class

<img width="267" alt="Screen Shot 2021-11-30 at 9 19 07 AM" src="https://user-images.githubusercontent.com/6599111/144067438-7288dae1-153b-4738-9324-c0704499b449.png">

## Testing Notes
This should be isolated to just the tags in the withdrawn section, so if they pass accessibility, it should be good.


## Ticket

https://openscience.atlassian.net/browse/ENG-3344
