### PR TITLE
[ENG-3482] Don't allow pure whitespace in abstract

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -35,7 +35,10 @@ const BasicsValidations = buildValidations({
     basicsAbstract: {
         description: 'Abstract',
         validators: [
-            validator('presence', true),
+            validator('presence', {
+                presence: true,
+                ignoreBlank: true,
+            }),
             validator('length', {
                 // currently min of 20 characters --
                 // this is what arXiv has as the minimum length of an abstract


### PR DESCRIPTION
## Purpose
- Stop allowing users to enter 20 white spaces to bypass validation for Abstract section


## Summary of Changes/Side Effects
- use `ignoreBlank` when validating the Abstract so users cannot just enter white space when revising a preprint (validation cannot be bypassed like this for the initial submission)
- Abstract section of osf.io/<preprint_guid>/edit no longer allows only-whitespace
![Screen Shot 2022-01-04 at 3 08 14 PM](https://user-images.githubusercontent.com/51409893/148117646-63e7aa43-a0b0-4b0b-a259-618226d0f448.png)



## Testing Notes
- Please verify that preprint submission (osf.io/preprints/submit/) and preprint updating (osf.io/<preprint_guid>/edit) workflows do not allow users to enter a blank or all-whitespace Abstract in the Basics section


## Ticket

https://openscience.atlassian.net/browse/ENG-3482

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
