### PR TITLE
[ENG-23] Show preprint view count

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -61,7 +61,7 @@ export default {
             download: 'Download',
             downloads: 'Downloads',
             download_file: 'Download file',
-            download_preprint: 'Download {{documentType.singular}}',
+            views: 'Views',
         },
         see_more: 'See more',
         see_less: 'See less',

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -44,9 +44,17 @@ export default Route.extend({
             }
         });
 
-        return this
-            .store
-            .findRecord('preprint', params.preprint_id);
+        return this.store.findRecord(
+            'preprint', params.preprint_id,
+            {
+                adapterOptions: {
+                    query: {
+                        'metrics[views]': 'total',
+                        'metrics[downloads]': 'total',
+                    },
+                },
+            },
+        );
     },
     actions: {
         error(error) {

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -61,6 +61,7 @@ export default Route.extend(Analytics, ResetScrollMixin, {
 
         this.set('fileDownloadURL', downloadUrl);
         this.set('preprint', preprint);
+        this.set('apiMeta', preprint.get('apiMeta'));
 
         if (!preprint.get('dateWithdrawn')) {
             const setupMetaData = preprint.get('provider')
@@ -82,6 +83,7 @@ export default Route.extend(Analytics, ResetScrollMixin, {
             fileDownloadURL: this.get('fileDownloadURL'),
             isPendingWithdrawal: this.get('isPendingWithdrawal'),
             isWithdrawn: model.get('dateWithdrawn') !== null,
+            apiMeta: this.get('apiMeta'),
         });
 
         run.scheduleOnce('afterRender', this, function() {

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -103,8 +103,8 @@
                     <div class="col-md-5">
                         {{!SHARE ROW}}
                         <div class="share-row p-sm osf-box-lt clearfix">
-                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'trackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download}}>{{t "content.share.download_preprint" documentType=model.provider.documentType}} </a>
-                            <div class=" p-v-xs pull-right">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}} </div>
+                            <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'trackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download}}>{{t "content.share.download" documentType=model.provider.documentType}} </a>
+                            <div class=" p-v-xs pull-right">{{t "content.share.views"}}: {{apiMeta.metrics.views}} | {{t "content.share.downloads"}}: {{apiMeta.metrics.downloads}} </div>
                         </div>
                         <div class="flexbox">
                             <div class="plaudit-widget">


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
- Use impact metrics to show preprint view count
- Switch download count to use impact download count as opposed to the `preprint.primaryFile.extra.downloads`

## Summary of Changes/Side Effects
- *Will need related ember-osf repo change to work*
- Added Views to preprint overview page
- Updated download count to be read from the impact metrics, as opposed to the `preprint.primaryFile.downloadCount`
- Reworded "Download preprint" to just say "Download" to avoid a display issue where the text is forced beneath onto the line below. (currently the highest viewed preprint has 187k views, most downloaded has 532k downloads)
  - without shortened label
   <img width="401" alt="Screen Shot 2022-01-14 at 3 30 04 PM" src="https://user-images.githubusercontent.com/51409893/149585741-6a48ada9-0261-441e-a936-cf95e1574f84.png">
  
  - with shortened label
  <img width="390" alt="Screen Shot 2022-01-14 at 3 34 13 PM" src="https://user-images.githubusercontent.com/51409893/149585812-e402f833-c5b7-4910-aeab-2123d349c365.png">




## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->


## Ticket

https://openscience.atlassian.net/browse/ENG-23

## Notes for Reviewer
- I've opted to serialize the request metadata into an `apiMeta` attribute, similar to how we handle record-specific metadata in ember-osf-web. Resource-level metadata is better supported in relationships or queries, but seems to be less 


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
