### PR TITLE
[ENG-3677] Add disclaimer to preprints metrics

### DIFF
--- a/app/controllers/content/index.js
+++ b/app/controllers/content/index.js
@@ -226,4 +226,6 @@ export default Controller.extend(Analytics, {
     _returnContributors(contributors) {
         return contributors;
     },
+
+    metricsStartDate: config.OSF.metricsStartDate,
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -62,7 +62,7 @@ export default {
             downloads: 'Downloads',
             download_file: 'Download file',
             views: 'Views',
-            metrics_disclaimer: 'Metrics are counted since 2019',
+            metrics_disclaimer: 'Metrics collected since {{date}}',
         },
         see_more: 'See more',
         see_less: 'See less',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -62,6 +62,7 @@ export default {
             downloads: 'Downloads',
             download_file: 'Download file',
             views: 'Views',
+            metrics_disclaimer: 'Metrics are counted since 2019',
         },
         see_more: 'See more',
         see_less: 'See less',

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -106,7 +106,9 @@
                             <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'trackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download}}>{{t "content.share.download" documentType=model.provider.documentType}} </a>
                             <div class=" p-v-xs pull-right">
                                 {{t "content.share.views"}}: {{apiMeta.metrics.views}} | {{t "content.share.downloads"}}: {{apiMeta.metrics.downloads}}
-                                {{#bs-tooltip}}{{t "content.share.metrics_disclaimer"}}{{/bs-tooltip}}
+                                {{#bs-tooltip}}
+                                    {{t "content.share.metrics_disclaimer" date=(moment-format this.metricsStartDate "YYYY-MM-DD")}}
+                                {{/bs-tooltip}}
                             </div>
                         </div>
                         <div class="flexbox">

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -104,7 +104,10 @@
                         {{!SHARE ROW}}
                         <div class="share-row p-sm osf-box-lt clearfix">
                             <a class="btn btn-primary p-v-xs" href={{fileDownloadURL}} onclick={{action 'trackNonContributors' 'link' 'Content - Download' model.primaryFile.links.download}}>{{t "content.share.download" documentType=model.provider.documentType}} </a>
-                            <div class=" p-v-xs pull-right">{{t "content.share.views"}}: {{apiMeta.metrics.views}} | {{t "content.share.downloads"}}: {{apiMeta.metrics.downloads}} </div>
+                            <div class=" p-v-xs pull-right">
+                                {{t "content.share.views"}}: {{apiMeta.metrics.views}} | {{t "content.share.downloads"}}: {{apiMeta.metrics.downloads}}
+                                {{#bs-tooltip}}{{t "content.share.metrics_disclaimer"}}{{/bs-tooltip}}
+                            </div>
                         </div>
                         <div class="flexbox">
                             <div class="plaudit-widget">

--- a/config/environment.js
+++ b/config/environment.js
@@ -83,6 +83,9 @@ module.exports = function(environment) {
             '1196-1961',
         ],
         plauditWidgetUrl: 'https://osf-review.plaudit.pub/embed/endorsements.js',
+        OSF: {
+            metricsStartDate: '2019-01-01',
+        },
     };
 
     if (environment === 'development') {


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
- Our metrics are looking a little fishy (suspiciously high download counts relative to view count for preprints submitted before 2019), so the API will only return trusty-worthy metrics from 2019 onward. Some preprints may have their numbers skewed because of this, so we will add a hover-text to indicate the dates that these metrics cover


## Summary of Changes/Side Effects
- Add hover text to download/view count on preprint detail
- Add new config `config.OSF.metricsStartDate` for start dates

## Testing Notes
When hovering the preprints view/download, there should be a disclaimer about the metrics
![image](https://user-images.githubusercontent.com/51409893/160007912-63895ec6-136e-40d9-b8d1-7156747a7f93.png)



## Ticket
https://openscience.atlassian.net/browse/ENG-3677

## Notes for Reviewer
There is a backend piece that will adjust the metrics to use only the metrics after 2019 (when metrics data may have gotten out of sync) here: https://github.com/CenterForOpenScience/osf.io/pull/9900

# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
