### PR TITLE
[ENG-4470] Reroute users to new search page

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,6 +1,7 @@
 import RSVP from 'rsvp';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
+import config from 'ember-get-config';
 import Analytics from 'ember-osf/mixins/analytics';
 
 import ResetScrollMixin from '../mixins/reset-scroll';
@@ -35,11 +36,15 @@ export default Route.extend(Analytics, ResetScrollMixin, {
     },
     actions: {
         search(q) {
-            let route = 'discover';
-
-            if (this.get('theme.isSubRoute')) { route = `provider.${route}`; }
-
-            this.transitionTo(route, { queryParams: { q } });
+            if (this.get('theme.isSubRoute')) {
+                // TODO Phase2 search improvement: reroute users to new branded preprint discover page
+                const route = 'provider.discover';
+                this.transitionTo(route, { queryParams: { q } });
+            } else {
+                // If OSF, reroute to new search page
+                window.location.href = `${this.host}/search?q=${q}&resourceType=osf:Preprints`;
+            }
         },
     },
+    host: config.OSF.url,
 });

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -31,6 +31,7 @@
                     </a>
                 </li>
             {{/if}}
+            {{!-- TODO Phase2 search improvement: Reroute users to new search page --}}
             <li><a class="" href='{{theme.pathPrefix}}discover' onclick={{action "click" "link" "Navbar - Search"}}>{{t "global.search"}}</a></li>
             <li>
                 <a href="https://cos.io/donate" onclick={{action "click" "link" (concat "Navbar - Donate")}}>


### PR DESCRIPTION
## Purpose
- Reroute users to the new search page after executing search


## Summary of Changes/Side Effects
- route users to new search page when they search in the text-box on preprints landing page
- add a comment for easy update for when we implement the re-designed branded preprint discover page


## Testing Notes
- Users should be taken to the new search page with whatever query they entered in the search box and preprints selected as the object filter type
- Reroute users to new search page when they execute a search in osf.io/preprints 
<img width="991" alt="image" src="https://github.com/CenterForOpenScience/ember-osf-preprints/assets/51409893/de812f77-f1d7-453f-8bf5-a1dceeb010ba">


## Ticket

https://openscience.atlassian.net/browse/ENG-4470

## Notes for Reviewer
- The branded navbar isn't being updated in this phase, but I added a comment into that component for my future self.


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
