### PR TITLE
[ENG-4460] Toggle assertions based on preprint-provider flag

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -135,184 +135,185 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                
-                    {{#with "Assertions" as |name|}}
-                        {{#preprint-form-section
-                            id="author-assertions"
-                            editMode=editMode
-                            name=name
-                            allowOpen=uploadValid
-                            canEdit=canEdit
-                            errorAction=(action 'error')
-                            as |hasOpened|
-                        }}
-                            {{preprint-form-header
+                    {{#if assertionsEnabled}}
+                        {{#with "Assertions" as |name|}}
+                            {{#preprint-form-section
+                                id="author-assertions"
                                 editMode=editMode
-                                assertionsSaveState=assertionsSaveState
-                                hasDataLinks=model.hasDataLinks
-                                dataLinks=model.dataLinks
-                                whyNoData=model.whyNoData
-                                hasPreregLinks=model.hasPreregLinks
-                                preregLinks=model.preregLinks
-                                whyNoPrereg=model.whyNoPrereg
                                 name=name
-                                valid=authorAssertionsValid
-                                isValidationActive=hasOpened
+                                allowOpen=uploadValid
+                                canEdit=canEdit
+                                errorAction=(action 'error')
+                                as |hasOpened|
                             }}
-                            {{#preprint-form-body class="sloan-assertions"}}
-                                
-                                <div role='radiogroup'>
-                                    <label>{{t "components.author-assertions.public_data.title"}}: <span class='required' /></label>
-                                    <input
-                                        type="radio"
-                                        id="hasDataLinksAvailable"
-                                        name="hasDataLinks"
-                                        onchange={{action "updateHasDataLinks" "available"}}
-                                        checked={{eq hasDataLinks "available"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasDataLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="hasDataLinksNo"
-                                        name="hasDataLinks"
-                                        onchange={{action "updateHasDataLinks" "no"}}
-                                        checked={{eq hasDataLinks "no"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasDataLinksNo">{{t "components.author-assertions.available.no"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="hasDataLinksNotApplicable"
-                                        name="hasDataLinks"
-                                        onchange={{action "updateHasDataLinks" "not_applicable"}}
-                                        checked={{eq hasDataLinks "not_applicable"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasDataLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
-                                </div>
-                                <br>
-                                {{#if (eq hasDataLinks 'available')}}
-                                    <div data-test-data-links-available>
-                                        {{#multiple-textbox-input
-                                            model=dataLinks
-                                                    labelAria=(t 'components.author-assertions.public_data.linksToData')
-                                        }}
-                                            {{t 'components.author-assertions.public_data.linksToData'}}: <span class='required' />
-                                        {{/multiple-textbox-input}}
-                                    </div>
-                                {{/if}}
-                                {{#if (eq hasDataLinks 'no')}}
-                                    <label>
-                                        {{t 'components.author-assertions.describe'}}:
-                                        {{validated-input
-                                            id='whyNoData'
-                                            inputType='textarea'
-                                            model=this
-                                            valuePath='whyNoData'
-                                            value=whyNoData
-                                        }}
-                                    </label>
-                                {{/if}}
-                                {{#if (eq hasDataLinks 'not_applicable')}}
-                                    <div data-test-data-links-not-applicable class='form-group'>
-                                        <textarea
-                                            type="text"
-                                            class='form-control'
-                                            disabled
+                                {{preprint-form-header
+                                    editMode=editMode
+                                    assertionsSaveState=assertionsSaveState
+                                    hasDataLinks=model.hasDataLinks
+                                    dataLinks=model.dataLinks
+                                    whyNoData=model.whyNoData
+                                    hasPreregLinks=model.hasPreregLinks
+                                    preregLinks=model.preregLinks
+                                    whyNoPrereg=model.whyNoPrereg
+                                    name=name
+                                    valid=authorAssertionsValid
+                                    isValidationActive=hasOpened
+                                }}
+                                {{#preprint-form-body class="sloan-assertions"}}
+                                    
+                                    <div role='radiogroup'>
+                                        <label>{{t "components.author-assertions.public_data.title"}}: <span class='required' /></label>
+                                        <input
+                                            type="radio"
+                                            id="hasDataLinksAvailable"
+                                            name="hasDataLinks"
+                                            onchange={{action "updateHasDataLinks" "available"}}
+                                            checked={{eq hasDataLinks "available"}}
                                         >
-                                            {{~t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType~}}
-                                        </textarea>
-                                    </div>
-                                {{/if}}
-                                <div class="assertionDescription">
-                                    {{t "components.author-assertions.public_data.description" documentType=currentProvider.documentType}}
-                                </div>
-                                
-                                <div role='radiogroup'>
-                                    <label>{{t "components.author-assertions.prereg.title"}}: <span class='required' /></label>
-                                    <input
-                                        type="radio"
-                                        id="hasPreregLinksAvailable"
-                                        name="hasPreregLinks"
-                                        onchange={{action "updateHasPreregLinks" "available"}}
-                                        checked={{eq hasPreregLinks "available"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasPreregLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="hasPreregLinksNo"
-                                        name="hasPreregLinks"
-                                        onchange={{action "updateHasPreregLinks" "no"}}
-                                        checked={{eq hasPreregLinks "no"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasPreregLinksNo">{{t "components.author-assertions.available.no"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="hasPreregLinksNotApplicable"
-                                        name="hasPreregLinks"
-                                        onchange={{action "updateHasPreregLinks" "not_applicable"}}
-                                        checked={{eq hasPreregLinks "not_applicable"}}
-                                    >
-                                    <label class="radioButtonLabel" for="hasPreregLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
-                                </div>
-                                <br>
-                                {{#if (eq hasPreregLinks 'available')}}
-                                    <div data-test-prereg-links-available class='form-group'>
-                                        {{#multiple-textbox-input
-                                            model=preregLinks
-                                                    labelAria=(t 'components.author-assertions.prereg.links')
-                                        }}
-                                            {{t 'components.author-assertions.prereg.links'}}: <span class='required' />
-                                        {{/multiple-textbox-input}}
-                                        <label for="preregLinkInfo">{{t 'components.author-assertions.prereg.type'}}: <span class='required' /></label>
-                                        {{#power-select
-                                            options=preregLinkInfoChoices
-                                            placeholder=(t 'components.author-assertions.prereg.chooseOne')
-                                            selected=preregLinkInfo
-                                            onchange=(action "updatePreregLinkInfo")
-                                            searchEnabled=false
-                                            as |option|
-                                        }}
-                                            <strong>{{t (concat 'components.author-assertions.prereg.' option)}}</strong>
-                                        {{/power-select}}
-                                    </div>
-                                {{/if}}
-                                {{#if (eq hasPreregLinks 'no')}}
-                                    <label>
-                                        {{t 'components.author-assertions.describe'}}:
-                                        {{validated-input
-                                            id='whyNoPrereg'
-                                            inputType='textarea'
-                                            model=this
-                                            valuePath='whyNoPrereg'
-                                            value=whyNoPrereg
-                                        }}
-                                    </label>
-                                {{/if}}
-                                {{#if (eq hasPreregLinks 'not_applicable')}}
-                                    <div data-test-prereg-links-not-applicable class='form-group'>
-                                        <textarea
-                                            type="text"
-                                            class='form-control'
-                                            disabled
+                                        <label class="radioButtonLabel" for="hasDataLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="hasDataLinksNo"
+                                            name="hasDataLinks"
+                                            onchange={{action "updateHasDataLinks" "no"}}
+                                            checked={{eq hasDataLinks "no"}}
                                         >
-                                            {{~t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType~}}
-                                        </textarea>
+                                        <label class="radioButtonLabel" for="hasDataLinksNo">{{t "components.author-assertions.available.no"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="hasDataLinksNotApplicable"
+                                            name="hasDataLinks"
+                                            onchange={{action "updateHasDataLinks" "not_applicable"}}
+                                            checked={{eq hasDataLinks "not_applicable"}}
+                                        >
+                                        <label class="radioButtonLabel" for="hasDataLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
                                     </div>
-                                {{/if}}
-                                <div class="assertionDescription">
-                                    {{t "components.author-assertions.prereg.description" documentType=currentProvider.documentType}}
-                                </div>
-                                
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <div class="pull-right">
-                                            <button {{action 'discardAuthorAssertions'}} data-test-author-assertions-discard class="btn btn-default" disabled={{unless authorAssertionsChanged true}} >{{t "global.discard"}}</button>
-                                            <button {{action 'saveAuthorAssertions'}} data-test-author-assertions-continue class="btn btn-primary" disabled={{unless authorAssertionsValid true}} >{{t "submit.body.save_continue"}}</button>
+                                    <br>
+                                    {{#if (eq hasDataLinks 'available')}}
+                                        <div data-test-data-links-available>
+                                            {{#multiple-textbox-input
+                                                model=dataLinks
+                                                        labelAria=(t 'components.author-assertions.public_data.linksToData')
+                                            }}
+                                                {{t 'components.author-assertions.public_data.linksToData'}}: <span class='required' />
+                                            {{/multiple-textbox-input}}
+                                        </div>
+                                    {{/if}}
+                                    {{#if (eq hasDataLinks 'no')}}
+                                        <label>
+                                            {{t 'components.author-assertions.describe'}}:
+                                            {{validated-input
+                                                id='whyNoData'
+                                                inputType='textarea'
+                                                model=this
+                                                valuePath='whyNoData'
+                                                value=whyNoData
+                                            }}
+                                        </label>
+                                    {{/if}}
+                                    {{#if (eq hasDataLinks 'not_applicable')}}
+                                        <div data-test-data-links-not-applicable class='form-group'>
+                                            <textarea
+                                                type="text"
+                                                class='form-control'
+                                                disabled
+                                            >
+                                                {{~t "components.author-assertions.public_data.not-applicable" documentType=currentProvider.documentType~}}
+                                            </textarea>
+                                        </div>
+                                    {{/if}}
+                                    <div class="assertionDescription">
+                                        {{t "components.author-assertions.public_data.description" documentType=currentProvider.documentType}}
+                                    </div>
+                                    
+                                    <div role='radiogroup'>
+                                        <label>{{t "components.author-assertions.prereg.title"}}: <span class='required' /></label>
+                                        <input
+                                            type="radio"
+                                            id="hasPreregLinksAvailable"
+                                            name="hasPreregLinks"
+                                            onchange={{action "updateHasPreregLinks" "available"}}
+                                            checked={{eq hasPreregLinks "available"}}
+                                        >
+                                        <label class="radioButtonLabel" for="hasPreregLinksAvailable">{{t "components.author-assertions.available.available"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="hasPreregLinksNo"
+                                            name="hasPreregLinks"
+                                            onchange={{action "updateHasPreregLinks" "no"}}
+                                            checked={{eq hasPreregLinks "no"}}
+                                        >
+                                        <label class="radioButtonLabel" for="hasPreregLinksNo">{{t "components.author-assertions.available.no"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="hasPreregLinksNotApplicable"
+                                            name="hasPreregLinks"
+                                            onchange={{action "updateHasPreregLinks" "not_applicable"}}
+                                            checked={{eq hasPreregLinks "not_applicable"}}
+                                        >
+                                        <label class="radioButtonLabel" for="hasPreregLinksNotApplicable">{{t "components.author-assertions.available.not_applicable"}}</label>
+                                    </div>
+                                    <br>
+                                    {{#if (eq hasPreregLinks 'available')}}
+                                        <div data-test-prereg-links-available class='form-group'>
+                                            {{#multiple-textbox-input
+                                                model=preregLinks
+                                                        labelAria=(t 'components.author-assertions.prereg.links')
+                                            }}
+                                                {{t 'components.author-assertions.prereg.links'}}: <span class='required' />
+                                            {{/multiple-textbox-input}}
+                                            <label for="preregLinkInfo">{{t 'components.author-assertions.prereg.type'}}: <span class='required' /></label>
+                                            {{#power-select
+                                                options=preregLinkInfoChoices
+                                                placeholder=(t 'components.author-assertions.prereg.chooseOne')
+                                                selected=preregLinkInfo
+                                                onchange=(action "updatePreregLinkInfo")
+                                                searchEnabled=false
+                                                as |option|
+                                            }}
+                                                <strong>{{t (concat 'components.author-assertions.prereg.' option)}}</strong>
+                                            {{/power-select}}
+                                        </div>
+                                    {{/if}}
+                                    {{#if (eq hasPreregLinks 'no')}}
+                                        <label>
+                                            {{t 'components.author-assertions.describe'}}:
+                                            {{validated-input
+                                                id='whyNoPrereg'
+                                                inputType='textarea'
+                                                model=this
+                                                valuePath='whyNoPrereg'
+                                                value=whyNoPrereg
+                                            }}
+                                        </label>
+                                    {{/if}}
+                                    {{#if (eq hasPreregLinks 'not_applicable')}}
+                                        <div data-test-prereg-links-not-applicable class='form-group'>
+                                            <textarea
+                                                type="text"
+                                                class='form-control'
+                                                disabled
+                                            >
+                                                {{~t "components.author-assertions.prereg.not-applicable" documentType=currentProvider.documentType~}}
+                                            </textarea>
+                                        </div>
+                                    {{/if}}
+                                    <div class="assertionDescription">
+                                        {{t "components.author-assertions.prereg.description" documentType=currentProvider.documentType}}
+                                    </div>
+                                    
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="pull-right">
+                                                <button {{action 'discardAuthorAssertions'}} data-test-author-assertions-discard class="btn btn-default" disabled={{unless authorAssertionsChanged true}} >{{t "global.discard"}}</button>
+                                                <button {{action 'saveAuthorAssertions'}} data-test-author-assertions-continue class="btn btn-primary" disabled={{unless authorAssertionsValid true}} >{{t "submit.body.save_continue"}}</button>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            {{/preprint-form-body}}
-                        {{/preprint-form-section}}
-                    {{/with}}
+                                {{/preprint-form-body}}
+                            {{/preprint-form-section}}
+                        {{/with}}
+                    {{/if}}
 
                     {{#with "Basics" as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -419,62 +420,63 @@
                         {{/preprint-form-section}}
                     {{/with}}
 
-                
-                    {{#with "COI" as |name|}}
-                        {{#preprint-form-section id="preprint-form-coi" class="sloan-assertions" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
-                            {{#preprint-form-body}}
-                                <div role='radiogroup'>
-                                    <input
-                                        type="radio"
-                                        id="coiYes"
-                                        name="coi"
-                                        value="Yes"
-                                        onchange={{action "updateHasCoi" true}}
-                                        checked={{eq hasCoi true}}
-                                    >
-                                    <label class="radioButtonLabel" for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
-                                    <input
-                                        type="radio"
-                                        id="coiNo"
-                                        name="coi"
-                                        value="No"
-                                        onchange={{action "updateHasCoi" false}}
-                                        checked={{eq hasCoi false}}
-                                    >
-                                    <label class="radioButtonLabel" for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
-                                    <span class='required' />
-                                </div>
-                                <br>
-                                {{#if hasCoi}}
-                                    <label>
-                                        {{t "submit.body.conflict_of_interest.describe"}} <span class='required' />
-                                        {{validated-input
-                                            inputType='textarea'
-                                            model=this valuePath='coiStatement'
-                                            documentType=currentProvider.documentType
-                                            value=coiStatement
-                                        }}
-                                    </label>
-                                {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
-                                    <div data-test-has-no-coi class='form-group'>
-                                        <input type="text" class='form-control' disabled placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                    {{#if assertionsEnabled}}
+                        {{#with "COI" as |name|}}
+                            {{#preprint-form-section id="preprint-form-coi" class="sloan-assertions" editMode=editMode name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
+                                {{preprint-form-header editMode=editMode coiSaveState=coiSaveState hasCoi=model.hasCoi coiStatement=model.conflictOfInterestStatement node=node name=name valid=coiValid isValidationActive=hasOpened}}
+                                {{#preprint-form-body}}
+                                    <div role='radiogroup'>
+                                        <input
+                                            type="radio"
+                                            id="coiYes"
+                                            name="coi"
+                                            value="Yes"
+                                            onchange={{action "updateHasCoi" true}}
+                                            checked={{eq hasCoi true}}
+                                        >
+                                        <label class="radioButtonLabel" for="coiYes">{{t "submit.body.conflict_of_interest.yes"}}</label>
+                                        <input
+                                            type="radio"
+                                            id="coiNo"
+                                            name="coi"
+                                            value="No"
+                                            onchange={{action "updateHasCoi" false}}
+                                            checked={{eq hasCoi false}}
+                                        >
+                                        <label class="radioButtonLabel" for="coiNo">{{t "submit.body.conflict_of_interest.no"}}</label>
+                                        <span class='required' />
                                     </div>
-                                {{/if}}
-                                <div class="assertionDescription">
-                                    {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
-                                </div>
-                                <div class="row">
-                                    <div class="col-md-12">
-                                        <div class="pull-right">
-                                            <button {{action 'discardCoi'}} data-test-coi-discard class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
-                                            <button {{action 'saveCoi'}} data-test-coi-continue class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
+                                    <br>
+                                    {{#if hasCoi}}
+                                        <label>
+                                            {{t "submit.body.conflict_of_interest.describe"}} <span class='required' />
+                                            {{validated-input
+                                                inputType='textarea'
+                                                model=this valuePath='coiStatement'
+                                                documentType=currentProvider.documentType
+                                                value=coiStatement
+                                            }}
+                                        </label>
+                                    {{else if (and (not hasCoi) (and (not-eq hasCoi undefined) (not-eq hasCoi null)))}}
+                                        <div data-test-has-no-coi class='form-group'>
+                                            <input type="text" class='form-control' disabled placeholder={{t "submit.body.conflict_of_interest.placeholder"}}>
+                                        </div>
+                                    {{/if}}
+                                    <div class="assertionDescription">
+                                        {{t "submit.body.conflict_of_interest.description" documentType=currentProvider.documentType}}
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="pull-right">
+                                                <button {{action 'discardCoi'}} data-test-coi-discard class="btn btn-default" disabled={{unless coiChanged true}} >{{t "global.discard"}}</button>
+                                                <button {{action 'saveCoi'}} data-test-coi-continue class="btn btn-primary" disabled={{unless coiValid true}} >{{t "submit.body.save_continue"}}</button>
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            {{/preprint-form-body}}
-                        {{/preprint-form-section}}
-                    {{/with}}
+                                {{/preprint-form-body}}
+                            {{/preprint-form-section}}
+                        {{/with}}
+                    {{/if}}
 
                     {{#with "Supplemental" as |name|}}
                         {{#preprint-form-section id="supplemental-materials" editMode=editMode class="preprint-form-upload" name=name allowOpen=uploadValid canEdit=canEdit errorAction=(action 'error') as |hasOpened|}}
@@ -612,8 +614,10 @@
                                         <p class="text-danger">{{unless savedAbstract (t "submit.body.submit.invalid.basics")}}</p>
                                         <p class="text-danger">{{unless savedSubjects (t "submit.body.submit.invalid.discipline")}}</p>
                                         <p class="text-danger">{{unless authorsValid (t "global.authors")}}</p>
-                                        <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
-                                        <p class="text-danger">{{unless savedAuthorAssertions (t "components.preprint-form-header.name.Assertions")}}</p>
+                                        {{#if assertionsEnabled}}
+                                            <p class="text-danger">{{unless savedCoi (t "submit.body.conflict_of_interest.title")}}</p>
+                                            <p class="text-danger">{{unless savedAuthorAssertions (t "components.preprint-form-header.name.Assertions")}}</p>
+                                        {{/if}}
                                     </span>
                                 {{/if}}
                                 <button class="btn btn-success btn-md m-t-md pull-right" disabled={{showValidationErrors}} {{action 'clickSubmit'}}>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#v0.36.0",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#feature\/custom-preprint-citation",
     "@centerforopenscience/eslint-config": "^2.0.0",
     "@centerforopenscience/osf-style": "1.9.0",
     "autoprefixer": "^7.1.2",

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -99,7 +99,7 @@ test('Initial properties', function (assert) {
         '_State.EXISTING': 'existing',
         filePickerState: 'start',
         supplementalPickerState: 'start',
-        '_names.length': 8,
+        '_names.length': 6,
         user: null,
         'availableLicenses.length': 0,
         node: null,
@@ -301,11 +301,7 @@ test('allSectionsValid computed property', function(assert) {
     ctrl.set('savedSubjects', true);
     assert.equal(ctrl.get('allSectionsValid'), false, 'Subjects saved - should be false');
     ctrl.set('authorsValid', true);
-    assert.equal(ctrl.get('allSectionsValid'), false, 'Authors valid - should be false');
-    ctrl.set('savedAuthorAssertions', true);
-    assert.equal(ctrl.get('allSectionsValid'), false, 'Author assertions saved - should be false');
-    ctrl.set('savedCoi', true);
-    assert.equal(ctrl.get('allSectionsValid'), true, 'COI saved - should be true');
+    assert.equal(ctrl.get('allSectionsValid'), true, 'Authors valid - should be true');
 });
 
 test('preprintFileChanged computed property', function(assert) {

--- a/tests/unit/controllers/submit-test.js
+++ b/tests/unit/controllers/submit-test.js
@@ -144,6 +144,15 @@ test('Initial properties', function (assert) {
 
 // Test COMPUTED PROPERTIES > SUBMIT CONTROLLER
 
+test('assertionsEnabled updates _names', function (assert) {
+    const ctrl = this.subject();
+    ctrl.set('selectedProvider', { assertionsEnabled: true });
+
+    assert.equal(ctrl.get('_names.length'), 8, 'assertionsEnabled adds 2 panels');
+    assert.ok(ctrl.get('_names').includes('COI'), 'assertionsEnabled adds COI panel');
+    assert.ok(ctrl.get('_names').includes('Assertions'), 'assertionsEnabled adds Assertions panel');
+});
+
 test('hasFile computed property', function(assert) {
     const ctrl = this.subject();
     assert.notOk(ctrl.get('hasFile'));
@@ -289,7 +298,7 @@ test('savedSubjects computed property', function(assert) {
     });
 });
 
-test('allSectionsValid computed property', function(assert) {
+test('allSectionsValid computed property for assertionsEnabled === false', function(assert) {
     const ctrl = this.subject();
     assert.equal(ctrl.get('allSectionsValid'), false, 'Nothing set - should be false');
     ctrl.set('savedTitle', true);
@@ -302,6 +311,26 @@ test('allSectionsValid computed property', function(assert) {
     assert.equal(ctrl.get('allSectionsValid'), false, 'Subjects saved - should be false');
     ctrl.set('authorsValid', true);
     assert.equal(ctrl.get('allSectionsValid'), true, 'Authors valid - should be true');
+});
+
+test('allSectionsValid computed property for assertionsEnabled === true', function(assert) {
+    const ctrl = this.subject();
+    ctrl.set('selectedProvider', { assertionsEnabled: true });
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Nothing set - should be false');
+    ctrl.set('savedTitle', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Title set - should be false');
+    ctrl.set('savedFile', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'File saved - should be false');
+    ctrl.set('savedAbstract', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Abstract saved - should be false');
+    ctrl.set('savedSubjects', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Subjects saved - should be false');
+    ctrl.set('authorsValid', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Authors valid - should be false');
+    ctrl.set('savedAuthorAssertions', true);
+    assert.equal(ctrl.get('allSectionsValid'), false, 'Author assertions saved - should be false');
+    ctrl.set('savedCoi', true);
+    assert.equal(ctrl.get('allSectionsValid'), true, 'COI saved - should be true');
 });
 
 test('preprintFileChanged computed property', function(assert) {


### PR DESCRIPTION
## Purpose
- Show/Hide Assertions/COI panels in submit page based on a preprint-provider flag (`assertions_enabled`)


## Summary of Changes/Side Effects
- Add `assertionsEnabled` flag to `submit` page controller
  - controls which panels are visible (hide COI and Assertions based on this flag)
  - controls which validations occur
  - controls which validation errors are shown
- Is based pretty heavily on un-doing a [prior PR](https://github.com/CenterForOpenScience/ember-osf-preprints/pull/732) to remove the reliance on sloan feature-flags

## Testing Notes
- Will need to toggle the `assertions_enabled` flag on the preprint_provider page in the admin app
- The `assertions_enabled` does not control whether we show/hide COI and/or Author Assertions on the preprint-detail page (e.g. osf.io/preprints/<provider-id>/<preprint-id>), so if a preprint is submitted with COI or Author Assertions, it will show up on the detail page regardless of the `assertions_enabled` flag on the provider

## Ticket

https://openscience.atlassian.net/browse/ENG-4460

## Notes for Reviewer
- It's easiest to read if you hide whitespace in the diff
- This will be released in conjunction with the changes in ember-osf found in [this PR](https://github.com/CenterForOpenScience/ember-osf/pull/467) to add the `assertionsEnabled` flag to the preprint-provider model


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
