### PR TITLE
Update taxonomy-top-list qp

### DIFF
--- a/app/components/taxonomy-top-list.js
+++ b/app/components/taxonomy-top-list.js
@@ -34,14 +34,14 @@ export default Component.extend(Analytics, {
             // subject param in the discover controller is expecting
             const subjectOdd = sortedList.objectAt(i);
             pair.pushObject({
-                path: [subjectOdd.get('path')],
+                path: `activeFilters=[{"propertyVisibleLabel":"Subject","propertyShortFormLabel":"subject","label":"${subjectOdd.get('text')}","value":"${subjectOdd.get('links.iri')}"}]`,
                 text: subjectOdd.get('text'),
             });
 
             if (sortedList.objectAt(i + 1)) {
                 const subjectEven = sortedList.objectAt(i + 1);
                 pair.pushObject({
-                    path: [subjectEven.get('path')],
+                    path: `activeFilters=[{"propertyVisibleLabel":"Subject","propertyShortFormLabel":"subject","label":"${subjectEven.get('text')}","value":"${subjectEven.get('links.iri')}"}]`,
                     text: subjectEven.get('text'),
                 });
             }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -36,13 +36,13 @@ export default Route.extend(Analytics, ResetScrollMixin, {
     },
     actions: {
         search(q) {
+            // remove trailing slash if it exists
+            const host = this.host.replace(/\/$/, '');
             if (this.get('theme.isSubRoute')) {
-                // TODO Phase2 search improvement: reroute users to new branded preprint discover page
-                const route = 'provider.discover';
-                this.transitionTo(route, { queryParams: { q } });
+                const { id } = this.get('theme');
+                window.location.href = `${host}/preprints/${id}/discover?q=${q}`;
             } else {
-                // If OSF, reroute to new search page
-                window.location.href = `${this.host}/search?q=${q}&resourceType=osf:Preprints`;
+                window.location.href = `${host}/search?q=${q}&resourceType=Preprint`;
             }
         },
     },

--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -3,7 +3,7 @@
         {{#each pair as |subject|}}
             <div class="col-xs-12 col-sm-6 subject-item">
                 <a
-                    href="{{osfUrl}}preprints/{{theme.provider.id}}/discover?subject={{subject.path}}"
+                    href="{{osfUrl}}preprints/{{theme.provider.id}}/discover?{{subject.path}}"
                     class="btn btn-primary p-sm"
                 >
                     {{subject.text}}


### PR DESCRIPTION
## Purpose
- Update query-params for links going to preprint discover page


## Summary of Changes/Side Effects
- Update query-params for landing page search textbox
- Update query-params for landing page "Browse by subjects" links (`taxonomy-top-list`)
  - No need to update `additional-provider-list`, as we will be dropping livedata preprint-provider and that's the only provider on Production that seems to have `additional_provider`

## Testing Notes
<!-- What needs to be tested?
Are there any edge cases that should be tested? -->


## Ticket

https://openscience.atlassian.net/browse/IN-

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
