### PR TITLE
[ENG-4907] Add moderation message to OSF Preprints

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -244,6 +244,7 @@ export default {
                         create: 'By creating this {{documentType.singular}}, you confirm that all contributors agree with sharing it and that you have the right to share this {{documentType.singular}}.',
                         submit: 'By submitting this {{documentType.singular}}, you confirm that all contributors agree with sharing it and that you have the right to share this {{documentType.singular}}.',
                     },
+                    osf_moderation_policy: 'You can read more about <a href="https://help.osf.io/article/592-preprint-moderation">OSF Preprints moderation policies</a> on the OSF Support Center',
                 },
                 invalid: {
                     description: 'The following section(s) must be completed before submitting this {{documentType.singular}}.',

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -603,6 +603,11 @@
                                 <p class="information">
                                     {{t moderationInformation documentType=currentProvider.documentType name=providerName reviewsWorkflow=(t workflow)}}
                                 </p>
+                                {{#if (eq currentProvider.id 'osf')}}
+                                    <p class="information">
+                                        {{t 'submit.body.submit.information.osf_moderation_policy'}}
+                                    </p>
+                                {{/if}}
                             {{else}}
                                 <p class="information">{{t generalInformation documentType=currentProvider.documentType name=providerName}}</p>
                             {{/if}}


### PR DESCRIPTION
<!-- Before you submit your Pull Request, make sure you picked the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features and non-hotfix bugfixes, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
- Add info text about our moderation policy to users submitting to OSF Preprints


## Summary of Changes/Side Effects
- Add translation text
- show text if users are submitting to OSF Preprints
- On the preprints/submit page:
![image](https://github.com/CenterForOpenScience/ember-osf-preprints/assets/51409893/a35779c6-7b1a-4d2d-aceb-2a7e4c0d1269)


## Testing Notes
- OSF Preprints should have its `reviews_workflow` changed to `post-moderation` in the admin app
- Message "You can read more about [OSF Preprints moderation policies](https://help.osf.io/article/592-preprint-moderation)..." should only show up for users submitting to OSF Preprints
  - Help link currently goes to a "Page not found", but will be made public upon release.
- Message should show/hide when users select OSF Preprints or a different provider in the "Select a service" panel in preprints/submit page. The message won't update until "Save and continue" is pressed


## Ticket

https://openscience.atlassian.net/browse/ENG-4907

## Notes for Reviewer
<!-- Any area you want the reviewer to pay special attention to or areas of concern?-->


# Reviewer Checklist

- [ ] meets requirements
- [ ] easy to understand
- [ ] DRY
- [ ] testable and includes test(s)
- [ ] changes described in `CHANGELOG.md`

<!-- Please strike through any checks that you think are not relevant for this PR and indicate why, e.g.

     - [ ] ~~easy to understand~~ *(necessarily complex)*
-->
